### PR TITLE
Fix for typo in nuts3.yaml

### DIFF
--- a/nomenclature/definitions/region/nuts3.yaml
+++ b/nomenclature/definitions/region/nuts3.yaml
@@ -6714,7 +6714,7 @@ RO321:
 RO322:
    name: Ilfov
    country: Romania
-   nuts1: RO322
+   nuts1: RO3
    nuts2: RO32
 
 RO411:


### PR DESCRIPTION
This PR fixes a typo with regard to the NUTS3 node `R322`.

It seems that the source file is not available anymore from the eurostat page (invalid url), so I cannot confirm if this is a problem in the original file.