### PR TITLE
Fixing Consumption variable allowed units

### DIFF
--- a/definitions/variable/economy/economy.yaml
+++ b/definitions/variable/economy/economy.yaml
@@ -2,7 +2,7 @@
 
 - Consumption:
     description: Total consumption of all goods, by all consumers in a region
-    unit: [million EUR_2020/yr, billion  v/yr]
+    unit: [million EUR_2020/yr, billion USD_2010/yr]
 
 - Consumption|Households:
     description: Total consumption of all goods, by households in a region


### PR DESCRIPTION
Probably a copy paste issue, but instead of `billion v/yr` you should have `billion USD_2010/yr` in the Consumption variable allowed units.