### PR TITLE
Skip aggregation for variables related to prices, unit-costs, shares, ...

### DIFF
--- a/definitions/variable/economy/economy.yaml
+++ b/definitions/variable/economy/economy.yaml
@@ -70,51 +70,62 @@
     description: Price index on <Product> level, relative to base year 2011
     note: The index equals 1 in 2011, the reference year
     unit: index
+    skip-region-aggregation: true
 
 - Capital Price Index:
     description: Price index of capital, relative to base year 2011
     note: The index equals 1 in 2011, the reference year
     unit: index
+    skip-region-aggregation: true
 
 - Labor Price Index:
     description: Price index of wages, relative to base year 2011
     note: The index equals 1 in 2011, the reference year
     unit: index
+    skip-region-aggregation: true
 
 - Discount rate|Buildings:
     description: Discount rate for investments into residential and commercial buildings
     unit: '%'
+    skip-region-aggregation: true
 
 - Discount rate|Economy:
     description: Economy-wide discount rate (real interest rate of capital)
     unit: '%'
+    skip-region-aggregation: true
 
 - Discount rate|Electricity:
     description: Discount rate for investments in the electricity sector
     unit: '%'
+    skip-region-aggregation: true
 
 - Discount rate|Energy Supply:
     description: Discount rate for investments in energy supply sector
     unit: '%'
+    skip-region-aggregation: true
 
 - Discount rate|Industry:
     description: Discount rate for investments in installations in the industrial sector
     unit: '%'
+    skip-region-aggregation: true
 
 - Discount rate|Mobility:
     description: Discount rate for investments into mobility (e.g. vehicles),
       not including transport infrastructure)
     unit: '%'
+    skip-region-aggregation: true
 
 - Discount rate|Social:
     description: Social discount rate (should be reported if different from capital
       interest rate and used in the model to discount future costs and revenues)
     unit: '%'
+    skip-region-aggregation: true
 
 - Discount rate|Transport Infrastructure:
     description: Discount rate for investments into transport infrastructure
       (roads, railways, ports, airports, waterways etc.)
     unit: '%'
+    skip-region-aggregation: true
 
 - GDP|MER:
     description: GDP at market exchange rate
@@ -170,11 +181,13 @@
 - Population|Urban|Share:
     description: Share of population living in urban areas
     unit: '%'
+    skip-region-aggregation: true
 
 - Price|Carbon:
     description: Price of carbon (for regional aggregrates the weighted price of carbon
      by subregion should be used)
     unit: [EUR_2020/t CO2, USD_2010/t CO2]
+    skip-region-aggregation: true
 
 - Price|Final Energy|Residential|Electricity:
     description: Mean electricity price at the final level in the residential sector
@@ -182,6 +195,7 @@
       reflect the variability of different prices that are accessible to end-users
       (e.g., including regulated prices, prices by different competiting retailers).
     unit: [EUR_2020/GJ, USD_2010/GJ, EUR_2020/kWh]
+    skip-region-aggregation: true
 
 - Price|Final Energy|Residential|Gases|Natural Gas:
     description: Mean natural gas price at the final level in the residential sector
@@ -189,6 +203,7 @@
       reflect the variability of different prices that are accessible to end-users
       (e.g., including regulated prices, prices by different competiting retailers).
     unit: [EUR_2020/GJ,  USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Final Energy|Residential|Liquids|Biomass:
     description: Mean biofuel price at the final level in the residential sector
@@ -196,6 +211,7 @@
       reflect the variability of different prices that are accessible to end-users
       (e.g., including regulated prices, prices by different competiting retailers).
     unit: [EUR_2020/GJ,  USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Final Energy|Residential|Liquids|Oil:
     description: Mean light fuel oil price at the final level in the residential sector
@@ -203,6 +219,7 @@
       reflect the variability of different prices that are accessible to end-users
       (e.g., including regulated prices, prices by different competiting retailers).
     unit: [EUR_2020/GJ,  USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Final Energy|Residential|Solids|Biomass:
     description: Mean biomass price at the final level in the residential sector
@@ -210,6 +227,7 @@
       reflect the variability of different prices that are accessible to end-users
       (e.g., including regulated prices, prices by different competiting retailers).
     unit: [EUR_2020/GJ,  USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Final Energy|Residential|Solids|Coal:
     description: Mean coal price at the final level in the residential sector
@@ -217,67 +235,80 @@
       reflect the variability of different prices that are accessible to end-users
       (e.g., including regulated prices, prices by different competiting retailers).
     unit: [EUR_2020/GJ,  USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Primary Energy|Biomass:
     description: Biomass producer price
     unit: [EUR_2020/GJ, USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Primary Energy|Coal:
     description: Coal price at the primary level (i.e. the spot price at the global or
       regional market)
     unit: [EUR_2020/GJ, USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Primary Energy|Gas:
     description: Natural gas price at the primary level (i.e. the spot price at
       the global or regional market)
     unit: [EUR_2020/GJ, USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Primary Energy|Oil:
     description: Crude oil price at the primary level (i.e. the spot price at
                 the global or regional market)
     unit: [EUR_2020/GJ, USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Secondary Energy|Electricity:
     description: Electricity price at the secondary level, i.e. for large scale
                 consumers (e.g. aluminum production)
     notes: Prices should include the effect of carbon prices.
     unit: [EUR_2020/GJ, USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Secondary Energy|Gases|Natural Gas:
     description: Natural gas price at the secondary level, i.e. for large-scale
       consumers (e.g., gas power plant)
     notes: Prices should include the effect of carbon prices.
     unit: [EUR_2020/GJ, USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Secondary Energy|Hydrogen:
     description: Hydrogen price at the secondary level
     notes: Prices should include the effect of carbon prices.
     unit: [EUR_2020/GJ, USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Secondary Energy|Liquids:
     description: Liquid fuel price at the secondary level, i.e. petrol, diesel,
                 or weighted average
     notes: Prices should include the effect of carbon prices.
     unit: [EUR_2020/GJ, USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Secondary Energy|Liquids|Biomass:
     description: Biofuel price at the secondary level, i.e. for biofuel consumers
     unit: [EUR_2020/GJ, USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Secondary Energy|Liquids|Oil:
     description: Light fuel oil price at the secondary level, i.e. for large-scale
       consumers (e.g. oil power plant)
     notes: Prices should include the effect of carbon prices.
     unit: [EUR_2020/GJ, USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Secondary Energy|Solids|Biomass:
     description: Biomass price at the secondary level, i.e. for large-scale consumers
       (e.g. biomass power plant)
     notes: Prices should include the effect of carbon prices.
     unit: [EUR_2020/GJ, USD_2010/GJ]
+    skip-region-aggregation: true
 
 - Price|Secondary Energy|Solids|Coal:
     description: Coal price at the secondary level, i.e. for large-scale consumers
       (e.g. coal power plant)
     notes: Prices should include the effect of carbon prices.
     unit: [EUR_2020/GJ, USD_2010/GJ]
+    skip-region-aggregation: true

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -223,6 +223,7 @@
 - Emission Rate|CO2|Electricity|<Fuel>:
     description: CO2 emissions of a <Fuel> power plant.
     unit: tons/MWh
+    skip-region-aggregation: true
 - Emissions|CO2|Energy:
     description: CO2 emissions from energy use on supply and demand side (IPCC category
       1A, 1B)
@@ -581,3 +582,4 @@
 - Temperature|Global Mean:
     description: Change in global mean temperature relative to pre-industrial
     unit: °C
+    skip-region-aggregation: true

--- a/definitions/variable/technology/electricity-grid.yaml
+++ b/definitions/variable/technology/electricity-grid.yaml
@@ -38,6 +38,7 @@
 - Network|Electricity|Loss Factor:
     description: Transmission losses equal to the line flow times this factor
     unit:
+    skip-region-aggregation: true
 - Reserve|Electricity|Requirement|Manual Frequency Restoration:
     description: Manual frequency restoration reserve (mFRR) is used to relieve the
       automatic frequency restoration reserve during prolonged imbalances.
@@ -60,6 +61,7 @@
     description: Reactance. Lines need to have a reactance different from 0 in the
       case of a DC cable or a transportation modeling for an AC cable
     unit:
+    skip-region-aggregation: true
 - Reserve|Electricity|Replacement:
     description: Replacement reserve (RR) means the active power reserves available
       to restore or support the required level of frequency restoration reserve (FRR)
@@ -69,6 +71,8 @@
     description: Security factor to consider approximately N-1 contingencies. NTC
       = TTC x SecurityFactor
     unit:
+    skip-region-aggregation: true
 - Network|Electricity|Voltage Angle:
     description: Voltage angle at a node
     unit: Rad
+    skip-region-aggregation: true

--- a/definitions/variable/technology/electricity-operation.yaml
+++ b/definitions/variable/technology/electricity-operation.yaml
@@ -95,63 +95,82 @@
 - Operation Cost|Electricity|Biomass:
     description: Operation Cost of Biomass power plants
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Biomass|Traditionnal:
     description: Operation Cost of  Traditionnal Biomass power plants biomass from
       local and pre-existing resources mostly waste :domestic and agricultural waste,
       forest residues.
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Biomass|New and imported:
     description: Operation Cost of New+Imported biomass power plants biomass from
       dedicated energy crops and biomass imports.
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Nuclear:
     description: Operation Cost of nuclear power plants
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Geothermal:
     description: Operation Cost of Geothermal power plants
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Gas:
     description: Operation Cost of Gas power plants
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Gas|OCGT:
     description: Operation Cost of Open Cycle Gas Turbine power plants
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Gas|CCGT:
     description: Operation Cost of Combined Cycle Gas Turbine power plants
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Coal:
     description: Operation Cost of coal power plants
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Lignite:
     description: Operation Cost of Lignite power plants
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Oil:
     description: Operation Cost of Oil power plants
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Hydro|Reservoir:
     description: Operation Cost of "simple Hydro reservoir " units
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Hydro|Pumped Storage:
     description: Operation Cost of "Pumped Storage " units
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Hydro|Run of River:
     description: Operation Cost of "Run of River" units
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Hydro|Ocean:
     description: Operation Cost of Ocean Power plants
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Solar:
     description: Operation Cost of Photovoltaic power plants
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Wind|OnShore:
     description: Operation Cost of  Wind Onshore power plants
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Wind|OffShore:
     description: Operation Cost of  Wind OffShore power plants
     unit: EUR_2020
+    skip-region-aggregation: true
 - Operation Cost|Electricity|Electricity Storage:
     description: Operation Cost of energy storage systems, excl. hydro storage
     unit: EUR_2020
+    skip-region-aggregation: true
 - Reserve|Electricity|Automatic Frequency Restoration|Biomass:
     description: Automatic Frequency Restoration Reserve available for Traditionnal
       Biomass power plants; this amount is the maximum available for the grid operator
@@ -351,21 +370,28 @@
     description: Marginal Cost associated to the constraint in terms of CO2 emissions
       by the electricity power sector
     unit: EUR_2020/MWh
+    skip-region-aggregation: true
 - Marginal Cost|Final Energy|Electricity:
     description: Marginal Cost associated to the electricity demand constraint
     unit: EUR_2020/MWh
+    skip-region-aggregation: true
 - Marginal Cost|Maximum Flow|Electricity|Transmission:
     description: Marginal Cost associated to the maximum flow constraint in a line
     unit: EUR_2020/MWh
+    skip-region-aggregation: true
 - Marginal Cost|Minimum Flow|Electricity|Transmission:
     description: Marginal Cost associated to the minimum flow constraint in a line
     unit: EUR_2020/MWh
+    skip-region-aggregation: true
 - Marginal Cost|Network|Electricity|Demand|Inertia:
     description: Marginal Cost associated to the inertia requirement
     unit: EUR_2020/MWh
+    skip-region-aggregation: true
 - Marginal Cost|Network|Electricity|Demand|Reserve|Automatic Frequency Restoration:
     description: Marginal Cost associated to the Automatic Frequency Restoration requirement
     unit: EUR_2020/MWh
+    skip-region-aggregation: true
 - Marginal Cost|Network|Electricity|Demand|Reserve|Frequency Containment:
     description: Marginal Cost associated to the Frequency Containment requirement
     unit: EUR_2020/MWh
+    skip-region-aggregation: true

--- a/definitions/variable/technology/power-plant.yaml
+++ b/definitions/variable/technology/power-plant.yaml
@@ -8,24 +8,30 @@
     description: Constant term (intercept) to compute operational cost for generating
       electricity from <Fuel>
     unit: Mcal/hour
+    skip-region-aggregation: true
 - Operational Cost|Linear Term|Electricity Generation|<Fuel>:
     description: Linear term (slope) to compute operational cost for generating electricity
       from <Fuel>
     unit: Mcal/MWh
+    skip-region-aggregation: true
 - Operation and Maintenance Cost|Electricity|<Fuel>:
     description: Operation and maintenance cost for generating electricity from <Fuel>
     unit: EUR/MWh
+    skip-region-aggregation: true
 - Shut-Down Cost|Electricity|<Fuel>:
     description: Shutdown cost for a typical power plant generating electricity from
       <Fuel>
     unit: EUR
+    skip-region-aggregation: true
 - Start-Up Cost|Electricity|<Fuel>:
     description: Startup cost for a typical power plant generating electricity from
       <Fuel>
     unit: EUR
+    skip-region-aggregation: true
 - Variable Cost|Electricity|<Fuel>:
     description: Variable cost for generating electricity from <Fuel>
     unit: EUR/MWh
+    skip-region-aggregation: true
 - Number of Units|Electricity|<Fuel>:
     description: Number of power plant units generating electricity from <Fuel>
     unit:
@@ -37,10 +43,12 @@
     description: Minimum duration that a typical power plant generating electricity
       from <Fuel> has to remain online after start-up
     unit: hour
+    skip-region-aggregation: true
 - Minimum Off Duration|Electricity|<Fuel>:
     description: Minimum duration that a typical power plant generating electricity
       from <Fuel> has to remain offline after shut-down
     unit: hour
+    skip-region-aggregation: true
 - Forced Outage Rate|Electricity|<Fuel>:
     description: Unavailability as a share relative to Maximum Active Power due to
       unexpected outages (e.g., failures) of a typical power plant generating electricity
@@ -50,6 +58,7 @@
       the level of minimum active power, the plant has to be shut down for the duration
       of the outage.
     unit: '%'
+    skip-region-aggregation: true
 - Planned Outage Rate|Electricity|<Fuel>:
     description: Unavailability as a share relative to Maximum Active Power due to
       planned outages (e.g., maintaince, revision) of a typical power plant generating
@@ -59,25 +68,30 @@
       the level of minimum active power, the plant has to be shut down for the duration
       of the outage.
     unit: '%'
+    skip-region-aggregation: true
 - Mean Outage Duration|Electricity|<Fuel>:
     description: Mean duration of an outage of a typical power plant generating electricity
       from <Fuel>
     unit:
     - day
     - hour
+    skip-region-aggregation: true
 - Inertia|Electricity|<Fuel>:
     description: Inertia provided to the system by a typical power plant generating
       electricity from <Fuel>
     unit: second
+    skip-region-aggregation: true
 - Frequency Containment Reserve|Electricity|<Fuel>:
     description: Share of Maximum Active Power that can be committed to Frequency
       Containment Reserve by a typical power plant generating electricity from <Fuel>
     unit: '%'
+    skip-region-aggregation: true
 - Automatic Frequency Restoration Reserve|Electricity|<Fuel>:
     description: Share of Maximum Active Power that can be committed to Automatic
       Frequency Restoration Reserve by a typical power plant generating electricity
       from <Fuel>
     unit: '%'
+    skip-region-aggregation: true
 - Operating Reserve|Up|Electricity|<Fuel>:
     description: Upwards operating reserve by a typical power plant generating electricity
       from <Fuel>
@@ -90,10 +104,12 @@
     description: Upward ramp limit by a typical power plant generating electricity
       from <Fuel>
     unit: MW/h
+    skip-region-aggregation: true
 - Maximum Ramping|Down|Electricity|<Fuel>:
     description: Downward ramp limit by a typical power plant generating electricity
       from <Fuel>
     unit: MW/h
+    skip-region-aggregation: true
 - Maximum Storage|Electricity|Hydro|Reservoir:
     description: Maximum volume of a reservoir expressed in energy
     unit:
@@ -107,9 +123,11 @@
 - Pumping Efficiency|Electricity|Hydro|Reservoir:
     description: Efficiency of pumping for a hydro reservoir power plant
     unit: '%'
+    skip-region-aggregation: true
 - Turbine Efficiency|Electricity|Hydro|Reservoir:
     description: Efficiency of turbining for a hydro reservoir power plant
     unit: '%'
+    skip-region-aggregation: true
 - Inflows|Electricity|Hydro|Reservoir:
     description: Inflows into a reservoir expressed in energy
     unit:
@@ -146,21 +164,27 @@
 - Pumping Efficiency|Electricity|Hydro|Pumped Storage:
     description: Efficiency of pumping for a pumped-storage hydro unit
     unit: '%'
+    skip-region-aggregation: true
 - Turbine Efficiency|Electricity|Hydro|Pumped Storage:
     description: Efficiency of turbining for a pumped-storage hydro unit
     unit: '%'
+    skip-region-aggregation: true
 - Load Factor|Electricity|Hydro|Run of River:
     description: Load factors for run-of-river power plants
     unit: '%'
+    skip-region-aggregation: true
 - Load Factor|Electricity|Solar:
     description: Load factors for solar power plants
     unit: '%'
+    skip-region-aggregation: true
 - Load Factor|Electricity|Wind|Offshore:
     description: Load factors for offshore wind power plants
     unit: '%'
+    skip-region-aggregation: true
 - Load Factor|Electricity|Wind|Onshore:
     description: Load factors for onshore wind power plants
     unit: '%'
+    skip-region-aggregation: true
 - Maximum Energy Charge|Electricity|Energy Storage System:
     description: This is the upper bound that energy storage system could charge energy
       at time "t".

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -22,39 +22,51 @@
 - Capital Cost|Electricity|<Fuel>:
     description: Capital cost for <Fuel>
     unit: USD_2010/kW
+    skip-region-aggregation: true
 - Capital Cost|Heat|Residential and Commercial|<Fuel>:
     description: Capital cost for <Fuel>
     unit: USD_2010/kW
+    skip-region-aggregation: true
 - Capital Cost|Heat|Industrial|<Fuel>:
     description: Capital cost for <Fuel>
     unit: USD_2010/kW
+    skip-region-aggregation: true
 - Capital Cost|Transportation|Freight|<Transport>:
     description: Capital cost for freight <Transport>
     unit: USD_2010/tkm
+    skip-region-aggregation: true
 - Capital Cost|Transportation|Passenger|<Transport>:
     description: Capital cost for passenger <Transport>
     unit: USD_2010/pkm
+    skip-region-aggregation: true
 - Fixed Cost|Electricity|<Fuel>:
     description: Fixed O&M cost for <Fuel>
     unit: USD_2010/kW/yr
+    skip-region-aggregation: true
 - Fixed Cost|Heat|Residential and Commercial|<Fuel>:
     description: Fixed O&M for <Fuel>
     unit: USD_2010/kW/yr
+    skip-region-aggregation: true
 - Fixed Cost|Heat|Industrial|<Fuel>:
     description: Fixed O&M for <Fuel>
     unit: USD_2010/kW/yr
+    skip-region-aggregation: true
 - Fixed Cost|Transportation|Freight|<Transport>:
     description: Capital cost for freight <Transport>
     unit: USD_2010/tkm/yr
+    skip-region-aggregation: true
 - Fixed Cost|Transportation|Passenger|<Transport>:
     description: Capital cost for passenger <Transport>
     unit: USD_2010/pkm/yr
+    skip-region-aggregation: true
 - Variable Cost|Heat|Residential and Commercial|<Fuel>:
     description: Capital cost for <Fuel>
     unit: USD_2010/MWh
+    skip-region-aggregation: true
 - Variable Cost|Heat|Industrial|<Fuel>:
     description: Capital cost for <Fuel>
     unit: USD_2010/MWh
+    skip-region-aggregation: true
 - Investment|Energy Efficiency:
     description: Investments into the efficiency-increasing components of energy demand
       technologies


### PR DESCRIPTION
This PR relates to #130, supporting automated region-processing when uploading scenario data to an IIASA Scenario Explorer instance. It adds a "skip-region-aggregation" attribute to all variables that should not be simply summed up over regions (e.g., prices, per-unit costs, shares).