### PR TITLE
Allow validation of directional data

### DIFF
--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -38,7 +38,7 @@ def test_validate_fail():
     assert not (validate(df.rename(region={"Europe": "foo"})))
 
 
-def _test_validate_directional():
+def test_validate_directional():
     # test that validation works as expected with directional data
     assert validate(df.rename(region={"Europe": "Austria>Germany"}))
     assert not validate(df.rename(region={"Europe": "Austria>foo"}))


### PR DESCRIPTION
When migrating to the new **nomenclature-iamc** package, the feature to validate directional data (i.e., a region column of the structure *Region A>Region B*) was dropped.

This PR (re)activates the test for directional-data validation and adds a quick-fix to the workflow which does the following:
 - if any directional data exists in the scenario data to be validated
   - check if the directional data is of the right structure (not *Region A>Region B>Region C*; both the origin and destination region must exist in the codelist
   - add the directional "region" to the codelist
 - validate the scenario data against the (extended) region codelist
 