### PR TITLE
Use dedicated tag for electricity-input

### DIFF
--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -265,8 +265,8 @@
     description: CO2 emissions from agriculture, forestry and other land use (IPCC
       category 3)
     unit: Mt CO2/yr
-- Emission Rate|CO2|Electricity|<Fuel>:
-    description: CO2 emissions of a <Fuel> power plant.
+- Emission Rate|CO2|Electricity|<Electricity Input>:
+    description: CO2 emissions of a <Electricity Input> power plant
     unit: tons/MWh
     skip-region-aggregation: true
 - Emissions|CO2|Energy:

--- a/definitions/variable/energy/energy-secondary.yaml
+++ b/definitions/variable/energy/energy-secondary.yaml
@@ -7,8 +7,8 @@
 - Secondary Energy|Electricity:
     description: Total net electricity production
     unit: EJ/yr
-- Secondary Energy|Electricity|<Fuel>:
-    description: Net electricity production from <Fuel>
+- Secondary Energy|Electricity|<Electricity Input>:
+    description: Net electricity production from <Electricity Input>
     unit: EJ/yr
 - Secondary Energy|Electricity|Curtailment:
     description: Curtailment of electricity production due to oversupply from

--- a/definitions/variable/tag_electricity_input_types.yaml
+++ b/definitions/variable/tag_electricity_input_types.yaml
@@ -1,0 +1,193 @@
+# This list of inputs will replace any occurrence of `<Electricity Input>`
+# in a variable-definition yaml file
+
+# This list is intended for use as input fuel to the power sector
+
+- <Electricity Input>:
+  - Biomass:
+      description: purpose-grown biomass, crop residues, forest industry waste,
+        solid waste from domestic, agricultural or municipal sources
+  - Biomass|w/ CCS:
+      description: purpose-grown biomass, crop residues, forest industry waste,
+        solid waste from domestic, agricultural or municipal sources
+        with a CO2 capture component
+  - Biomass|w/o CCS:
+      description: purpose-grown biomass, crop residues, forest industry waste,
+        solid waste from domestic, agricultural or municipal sources
+        with freely vented CO2 emissions
+
+  - Biomass|Traditional:
+      description: traditional biomass (domestic and agricultural waste,
+        forest residues)
+  - Biomass|Traditional|w/ CCS:
+      description: traditional biomass (domestic and agricultural waste,
+        forest residues) with a CO2 capture component
+  - Biomass|Traditional|w/o CCS:
+      description: traditional biomass (domestic and agricultural waste,
+        forest residues) with freely vented CO2 emissions
+
+  - Biomass|New and Imported:
+      description: biomass from dedicated energy crops and biomass imports
+  - Biomass|New and Imported|w/ CCS:
+      description: biomass from dedicated energy crops and biomass imports
+        with a CO2 capture component
+  - Biomass|New and Imported|w/o CCS:
+      description: biomass from dedicated energy crops and biomass imports
+        with freely vented CO2 emissions
+
+  - Fossil:
+      description: all fossil fuels (crude oil, coal, natural gas)
+  - Fossil|w/ CCS:
+      description: all fossil fuels (crude oil, coal, natural gas)
+        with a CO2 capture component
+  - Fossil|w/o CCS:
+      description: all fossil fuels (crude oil, coal, natural gas)
+        with freely vented CO2 emissions
+
+  - Coal:
+      description: coal (including hard coal and lignite)
+  - Coal|w/ CCS:
+      description: coal (including hard coal and lignite) with a CO2 capture component
+  - Coal|w/o CCS:
+      description: coal (including hard coal and lignite)
+        with freely vented CO2 emissions
+
+  - Coal|Lignite:
+      description: lignite coal and sub-bituminous coal
+  - Coal|Lignite|w/ CCS:
+      description: lignite coal and sub-bituminous coal with a CO2 capture component
+  - Coal|Lignite|w/o CCS:
+      description: lignite coal and sub-bituminous coal with freely vented CO2 emissions
+
+  - Coal|Hard coal:
+      description: anthracite and bituminous coal
+  - Coal|Hard coal|w/ CCS:
+      description: anthracite and bituminous coal with a CO2 capture component
+  - Coal|Hard coal|w/o CCS:
+      description: anthracite and bituminous coal with freely vented CO2 emissions
+
+  - Gas:
+      description: natural gas (including methane from biomass or hydrogenation)
+  - Gas|w/ CCS:
+      description: natural gas (including methane from biomass or hydrogenation)
+        with a CO2 capture component
+  - Gas|w/o CCS:
+      description: natural gas (including methane from biomass or hydrogenation)
+        with freely vented CO2 emissions
+
+  - Gas|OCGT:
+      description: natural gas (including methane from biomass or hydrogenation)
+        in an open-cycle gas turbine (OCGT) power plant
+  - Gas|OCGT|w/ CCS:
+      description: natural gas (including methane from biomass or hydrogenation)
+        in an open-cycle gas turbine (OCGT) power plant with a CO2 capture component
+  - Gas|OCGT|w/o CCS:
+      description: natural gas (including methane from biomass or hydrogenation)
+        in an open-cycle gas turbine (OCGT) power plant with freely vented CO2 emissions
+
+  - Gas|CCGT:
+      description: natural gas (including methane from biomass or hydrogenation)
+        in a combined-cycle gas turbine (CCGT) power plant
+  - Gas|CCGT|w/ CCS:
+      description: natural gas (including methane from biomass or hydrogenation)
+        in a combined-cycle gas turbine (CCGT) power plant with a CO2 capture component
+  - Gas|CCGT|w/o CCS:
+      description: natural gas (including methane from biomass or hydrogenation)
+        in a combined-cycle gas turbine (CCGT) power plant with freely vented CO2 emissions
+
+  - Gas|Fossil:
+      description: fossil natural gas (excluding methane from biomass or hydrogenation)
+  - Gas|Fossil|w/ CCS:
+      description: fossil natural gas (excluding methane from biomass or hydrogenation)
+        with a CO2 capture component
+  - Gas|Fossil|w/o CCS:
+      description: fossil natural gas (excluding methane from biomass or hydrogenation)
+        with freely vented CO2 emissions
+
+  - Gas|Biomethane:
+      description: biomethane (upgraded biogas)
+  - Gas|Biomethane|w/ CCS:
+      description: biomethane (upgraded biogas) with a CO2 capture component
+  - Gas|Biomethane|w/o CCS:
+      description: biomethane (upgraded biogas) with freely vented CO2 emissions
+
+  - Gas|Synthetic Methane:
+      description: synthetic methane (methanation of hydrogen)
+  - Gas|Synthetic Methane|w/ CCS:
+      description: synthetic methane (methanation of hydrogen)
+        with a CO2 capture component
+  - Gas|Synthetic Methane|w/o CCS:
+      description: synthetic methane (methanation of hydrogen)
+        with freely vented CO2 emissions
+
+  - Oil:
+      description: refined liquid oil products
+  - Oil|w/ CCS:
+      description: refined liquid oil products with a CO2 capture component
+  - Oil|w/o CCS:
+      description: refined liquid oil products with freely vented CO2 emissions
+
+  - Nuclear:
+      description: nuclear energy
+
+  - Hydrogen:
+      description: hydrogen
+
+  - Hydrogen|Fuel Cell:
+      description: hydrogen via fuel cells
+
+  - Hydrogen|OCGT:
+      description: hydrogen used in OCGT power plants
+
+  - Non-Biomass Renewables:
+      description: hydro, wind, solar, geothermal, ocean, and other renewable sources
+        excluding bioenergy
+
+  - Hydro:
+      description: hydropower
+
+  - Hydro|Run of River:
+      description: run-of-river hydro power plants (i.e. without storage capacity)
+
+  - Hydro|Pumped Storage:
+      description: hydropower systems with short-term storage capacity
+        (including pumping turbines)
+      notes: This hydropower system has two water reservoirs at different elevations.
+        The definition follows the convention established
+        by the ENTSO-E transparency platform (https://transparency.entsoe.eu).
+
+  - Hydro|Reservoir:
+      description: hydropower systems with seasonal storage capacity
+        (possibly including pumping turbines)
+      notes: This definition follows the convention established
+        by the ENTSO-E transparency platform (https://transparency.entsoe.eu).
+
+  - Solar:
+      description: solar energy including PV and CSP
+
+  - Solar|CSP:
+      description: concentrating/concentrated solar power (CSP)
+
+  - Solar|PV:
+      description: solar photovoltaics (PV)
+
+  - Wind:
+      description: wind energy (on- and offshore)
+
+  - Wind|Offshore:
+      description: offshore wind energy
+
+  - Wind|Onshore:
+      description: onshore wind energy
+
+  - Geothermal:
+      description: geothermal energy (including hydrothermal systems)
+
+  - Ocean:
+      description: ocean energy
+
+  - Heatpump:
+      description: energy generation from heatpumps
+
+  - Other:
+      description: other energy sources and fuels not explicitely listed

--- a/definitions/variable/tag_fuel_types.yaml
+++ b/definitions/variable/tag_fuel_types.yaml
@@ -1,7 +1,7 @@
 # This list of inputs will replace any occurrence of `<Fuel>`
 # in a variable-definition yaml file
 
-# This list is intended for use as input fuel to the power sector
+# This list is intended for use as fuels except for the power sector
 
 - <Fuel>:
   - Biomass:
@@ -127,9 +127,6 @@
   - Oil|w/o CCS:
       description: refined liquid oil products with freely vented CO2 emissions
 
-  - Nuclear:
-      description: nuclear energy
-
   - Hydrogen:
       description: hydrogen
 
@@ -139,46 +136,8 @@
   - Hydrogen|OCGT:
       description: hydrogen used in OCGT power plants
 
-  - Non-Biomass Renewables:
-      description: hydro, wind, solar, geothermal, ocean, and other renewable sources
-        excluding bioenergy
-
-  - Hydro:
-      description: hydropower
-
-  - Hydro|Run of River:
-      description: run-of-river hydro power plants (i.e. without storage capacity)
-
-  - Hydro|Pumped Storage:
-      description: hydropower systems with short-term storage capacity
-        (including pumping turbines)
-      notes: This hydropower system has two water reservoirs at different elevations.
-        The definition follows the convention established
-        by the ENTSO-E transparency platform (https://transparency.entsoe.eu).
-
-  - Hydro|Reservoir:
-      description: hydropower systems with seasonal storage capacity
-        (possibly including pumping turbines)
-      notes: This definition follows the convention established
-        by the ENTSO-E transparency platform (https://transparency.entsoe.eu).
-
   - Solar:
-      description: solar energy including PV and CSP
-
-  - Solar|CSP:
-      description: concentrating/concentrated solar power (CSP)
-
-  - Solar|PV:
-      description: solar photovoltaics (PV)
-
-  - Wind:
-      description: wind energy (on- and offshore)
-
-  - Wind|Offshore:
-      description: offshore wind energy
-
-  - Wind|Onshore:
-      description: onshore wind energy
+      description: direct use of solar energy (heat)
 
   - Geothermal:
       description: geothermal energy (including hydrothermal systems)
@@ -188,9 +147,6 @@
 
   - Electricity:
       description: electricity
-
-  - Heatpump:
-      description: energy generation from heatpumps
 
   - Other:
       description: other energy sources and fuels not explicitely listed

--- a/definitions/variable/tag_fuel_types.yaml
+++ b/definitions/variable/tag_fuel_types.yaml
@@ -1,15 +1,7 @@
-# This list of fuels will replace any occurrence of `<Fuel>`
+# This list of inputs will replace any occurrence of `<Fuel>`
 # in a variable-definition yaml file
 
-# All fuels that have the attribute "ccs: True" have two sub-categories
-# "w/ CCS": with a CO2 capture component
-# "w/o CCS": with freely vented CO2 emissions (example "Coal|w/o CCS")
-#
-#   e.g., the energy type "Coal" used for electricity generation
-#   is described by three variables:
-#   - Secondary Energy|Electricity|Coal
-#   - Secondary Energy|Electricity|Coal|Coal|w/ CCS
-#   - Secondary Energy|Electricity|Coal|Coal|w/o CCS
+# This list is intended for use as input fuel to the power sector
 
 - <Fuel>:
   - Biomass:
@@ -194,14 +186,8 @@
   - Ocean:
       description: ocean energy
 
-  - Electricity:
-      description: energy generation from electricity
-
-  - Electricity|Heatpump:
+  - Heatpump:
       description: energy generation from heatpumps
-
-  - Electricity|Other:
-      description: energy generation from other electrification technologies
 
   - Other:
       description: other energy sources and fuels not explicitely listed

--- a/definitions/variable/tag_fuel_types.yaml
+++ b/definitions/variable/tag_fuel_types.yaml
@@ -186,6 +186,9 @@
   - Ocean:
       description: ocean energy
 
+  - Electricity:
+      description: electricity
+
   - Heatpump:
       description: energy generation from heatpumps
 

--- a/definitions/variable/technology/electricity-operation.yaml
+++ b/definitions/variable/technology/electricity-operation.yaml
@@ -19,27 +19,26 @@
 - Active Power|Electricity|Load Curtailment:
     description: Energy curtailed - from the system point of view is equivalent to
       generation of Active Power
-    unit: MWh
+    unit: GWh
 - Active Power|Electricity|Load Shifting:
     description: Energy shifted - from the system point of view is equivalent to generation
       of Active Power
-    unit: MWh
+    unit: GWh
 - Active Power|Electricity|Electricity Storage:
     description: Active Power of energy storage systems, excl. hydro storage
-    unit: MWh
+    unit: GWh
 - Storage|Electricity|Hydro|Reservoir:
     description: Available storage of "simple Hydro reservoir " units
-    unit: MWh
+    unit: GWh
 - Storage|Electricity|Hydro|Pumped Storage:
     description: Available storage of "Pumped Storage " units
-    unit: MWh
+    unit: GWh
 - Storage|Electricity|Energy Storage System:
     description: Available storage of energy storage systems, excl. hydro storage
-    unit: MWh
+    unit: GWh
 - Storage|Electricity|Load Curtailment:
     description: remaining amount of curtailement
-    unit: MWh
-    - GWh
+    unit: GWh
 
 - Operation Cost|Electricity|<Electricity Input>:
     description: Operation Cost of <Electricity Input> power plants
@@ -50,16 +49,14 @@
     description: Automatic Frequency Restoration Reserve available for <Electricity Input>
      power plants; this amount is the maximum available for the grid operator considering
      the commitment decisions taken by the model
-    unit:
-    - GWh
+    unit: GWh
     skip-region-aggregation: false
 
 - Reserve|Electricity|Frequency Containment|<Electricity Input>:
     description: Frequency Containment Reserve available for <Electricity Input>
      power plants; this amount is the maximum available for the grid operator considering
      the commitment decisions taken by the model
-    unit:
-    - GWh
+    unit: GWh
     skip-region-aggregation: false
 
 - Marginal Cost|CO2 Emissions|Electricity:

--- a/definitions/variable/technology/electricity-operation.yaml
+++ b/definitions/variable/technology/electricity-operation.yaml
@@ -12,63 +12,10 @@
 #   - Flows in transmission lines
 # Demand not served
 
-- Active Power|Electricity|Biomass:
-    description: Active power of Biomass power plants
-    unit: MWh
-- Active Power|Electricity|Biomass|Traditional:
-    description: Active power of  Traditional Biomass power plants biomass from local
-      and pre-existing resources mostly waste :domestic and agricultural waste, forest
-      residues.
-    unit: MWh
-- Active Power|Electricity|Biomass|New and imported:
-    description: Active power of New+Imported biomass power plants biomass from dedicated
-      energy crops and biomass imports.
-    unit: MWh
-- Active Power|Electricity|Nuclear:
-    description: Active power of nuclear power plants
-    unit: MWh
-- Active Power|Electricity|Gas:
-    description: Active power of Gas power plants
-    unit: MWh
-- Active Power|Electricity|Gas|OCGT:
-    description: Active power of Open Cycle Gas Turbine power plants
-    unit: MWh
-- Active Power|Electricity|Gas|CCGT:
-    description: Active power of Combined Cycle Gas Turbine power plants
-    unit: MWh
-- Active Power|Electricity|Coal:
-    description: Active power of coal power plants
-    unit: MWh
-- Active Power|Electricity|Lignite:
-    description: Active power of Lignite power plants
-    unit: MWh
-- Active Power|Electricity|Oil:
-    description: Active power of oil power plants
-    unit: MWh
-- Active Power|Electricity|Geothermal:
-    description: Active power of Geothermal power plants
-    unit: MWh
-- Active Power|Electricity|Hydro|Reservoir:
-    description: Active power of "simple Hydro reservoir " units
-    unit: MWh
-- Active Power|Electricity|Hydro|Pumped Storage:
-    description: Active power of "Pumped Storage " units
-    unit: MWh
-- Active Power|Electricity|Hydro|Run of River:
-    description: Active power of "Run of River" units
-    unit: MWh
-- Active Power|Electricity|Hydro|Ocean:
-    description: Active power of Ocean power plants
-    unit: MWh
-- Active Power|Electricity|Solar:
-    description: Active power of Photovoltaic power plants
-    unit: MWh
-- Active Power|Electricity|Wind|OnShore:
-    description: Active power of  Wind Onshore power plants
-    unit: MWh
-- Active Power|Electricity|Wind|OffShore:
-    description: Active power of  Wind OffShore power plants
-    unit: MWh
+- Active Power|Electricity|<Fuel>:
+    description: Active power of <Fuel> power plants
+    unit: GWh
+
 - Active Power|Electricity|Load Curtailment:
     description: Energy curtailed - from the system point of view is equivalent to
       generation of Active Power
@@ -92,280 +39,29 @@
 - Storage|Electricity|Load Curtailment:
     description: remaining amount of curtailement
     unit: MWh
-- Operation Cost|Electricity|Biomass:
-    description: Operation Cost of Biomass power plants
+    - GWh
+
+- Operation Cost|Electricity|<Fuel>:
+    description: Operation Cost of <Fuel> power plants
     unit: EUR_2020
     skip-region-aggregation: true
-- Operation Cost|Electricity|Biomass|Traditionnal:
-    description: Operation Cost of  Traditionnal Biomass power plants biomass from
-      local and pre-existing resources mostly waste :domestic and agricultural waste,
-      forest residues.
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Biomass|New and imported:
-    description: Operation Cost of New+Imported biomass power plants biomass from
-      dedicated energy crops and biomass imports.
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Nuclear:
-    description: Operation Cost of nuclear power plants
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Geothermal:
-    description: Operation Cost of Geothermal power plants
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Gas:
-    description: Operation Cost of Gas power plants
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Gas|OCGT:
-    description: Operation Cost of Open Cycle Gas Turbine power plants
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Gas|CCGT:
-    description: Operation Cost of Combined Cycle Gas Turbine power plants
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Coal:
-    description: Operation Cost of coal power plants
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Lignite:
-    description: Operation Cost of Lignite power plants
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Oil:
-    description: Operation Cost of Oil power plants
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Hydro|Reservoir:
-    description: Operation Cost of "simple Hydro reservoir " units
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Hydro|Pumped Storage:
-    description: Operation Cost of "Pumped Storage " units
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Hydro|Run of River:
-    description: Operation Cost of "Run of River" units
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Hydro|Ocean:
-    description: Operation Cost of Ocean Power plants
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Solar:
-    description: Operation Cost of Photovoltaic power plants
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Wind|OnShore:
-    description: Operation Cost of  Wind Onshore power plants
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Wind|OffShore:
-    description: Operation Cost of  Wind OffShore power plants
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Operation Cost|Electricity|Electricity Storage:
-    description: Operation Cost of energy storage systems, excl. hydro storage
-    unit: EUR_2020
-    skip-region-aggregation: true
-- Reserve|Electricity|Automatic Frequency Restoration|Biomass:
-    description: Automatic Frequency Restoration Reserve available for Traditionnal
-      Biomass power plants; this amount is the maximum available for the grid operator
-      considering the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Biomass|Traditionnal:
-    description: Automatic Frequency Restoration Reserve available for  Traditionnal
-      Biomass power plants; this amount is the maximum available for the grid operator
-      considering the commitment decisions taken by the model biomass from local and
-      pre-existing resources mostly waste :domestic and agricultural waste, forest
-      residues.
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Biomass|New and imported:
-    description: Automatic Frequency Restoration Reserve available for New+Imported
-      biomass power plants; this amount is the maximum available for the grid operator
-      considering the commitment decisions taken by the model biomass from dedicated
-      energy crops and biomass imports.
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Nuclear:
-    description: Automatic Frequency Restoration Reserve available for nuclear power
-      plants; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Geothermal:
-    description: Automatic Frequency Restoration Reserve available for Geothermal
-      power plants; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Gas:
-    description: Automatic Frequency Restoration Reserve available for Gas power plants;
-      this amount is the maximum available for the grid operator considering the commitment
-      decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Gas|OCGT:
-    description: Automatic Frequency Restoration Reserve available for Open Cycle
-      Gas Turbine power plants; this amount is the maximum available for the grid
-      operator considering the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Gas|CCGT:
-    description: Automatic Frequency Restoration Reserve available for Combined Cycle
-      Gas Turbine power plants; this amount is the maximum available for the grid
-      operator considering the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Coal:
-    description: Automatic Frequency Restoration Reserve available for coal power
-      plants; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Lignite:
-    description: Automatic Frequency Restoration Reserve available for Lignite power
-      plants; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Oil:
-    description: Automatic Frequency Restoration Reserve available for Oil power plants;
-      this amount is the maximum available for the grid operator considering the commitment
-      decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Hydro|Reservoir:
-    description: Automatic Frequency Restoration Reserve available for "simple Hydro
-      reservoir " units; this amount is the maximum available for the grid operator
-      considering the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Pumped Storage:
-    description: Automatic Frequency Restoration Reserve available for "Pumped Storage
-      " units; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Hydro|Run of River:
-    description: Automatic Frequency Restoration Reserve available for "Run of River"
-      units; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Hydro|Ocean:
-    description: Automatic Frequency Restoration Reserve available for Ocean power
-      plants; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Solar:
-    description: Automatic Frequency Restoration Reserve available for Photovoltaic
-      power plants; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Wind|OnShore:
-    description: Automatic Frequency Restoration Reserve available for  Wind Onshore
-      power plants; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Wind|Available forfShore:
-    description: Automatic Frequency Restoration Reserve available for  Wind Available
-      forfShore power plants; this amount is the maximum available for the grid operator
-      considering the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Automatic Frequency Restoration|Electricity Storage:
-    description: Automatic Frequency Restoration Reserve available for energy storage
-      systems, excl. hydro storage; this amount is the maximum available for the grid
-      operator considering the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Biomass:
-    description: Frequency Containment Reserve available for  Traditionnal Biomass
-      power plants; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Biomass|Traditionnal:
-    description: Frequency Containment Reserve available for  Traditionnal Biomass
-      power plants; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model biomass from local and pre-existing
-      resources mostly waste :domestic and agricultural waste, forest residues.
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Biomass|New and imported:
-    description: Frequency Containment Reserve available for New+Imported biomass
-      power plants; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model biomass from dedicated energy crops
-      and biomass imports.
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Nuclear:
-    description: Frequency Containment Reserve available for nuclear power plants;
-      this amount is the maximum available for the grid operator considering the commitment
-      decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Geothermal:
-    description: Frequency Containment Reserve available for Geothermal power plants;
-      this amount is the maximum available for the grid operator considering the commitment
-      decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Gas:
-    description: Frequency Containment Reserve available for Gas power plants; this
-      amount is the maximum available for the grid operator considering the commitment
-      decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Gas|OCGT:
-    description: Frequency Containment Reserve available for Open Cycle Gas Turbine
-      power plants; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Gas|CCGT:
-    description: Frequency Containment Reserve available for Combined Cycle Gas Turbine
-      power plants; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Coal:
-    description: Frequency Containment Reserve available for coal power plants; this
-      amount is the maximum available for the grid operator considering the commitment
-      decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Lignite:
-    description: Frequency Containment Reserve available for Lignite power plants;
-      this amount is the maximum available for the grid operator considering the commitment
-      decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Oil:
-    description: Frequency Containment Reserve available for Oil power plants; this
-      amount is the maximum available for the grid operator considering the commitment
-      decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Hydro|Reservoir:
-    description: Frequency Containment Reserve available for "simple Hydro reservoir
-      " units; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Hydro|Pumped Storage:
-    description: Frequency Containment Reserve available for "Pumped Storage " units;
-      this amount is the maximum available for the grid operator considering the commitment
-      decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Hydro|Run of River:
-    description: Frequency Containment Reserve available for "Run of River" units;
-      this amount is the maximum available for the grid operator considering the commitment
-      decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Hydro|Ocean:
-    description: Frequency Containment Reserve available for Ocean Power plants; this
-      amount is the maximum available for the grid operator considering the commitment
-      decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Solar:
-    description: Frequency Containment Reserve available for Photovoltaic power plants;
-      this amount is the maximum available for the grid operator considering the commitment
-      decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Wind|OnShore:
-    description: Frequency Containment Reserve available for  Wind Onshore power plants;
-      this amount is the maximum available for the grid operator considering the commitment
-      decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Wind|OffShore:
-    description: Frequency Containment Reserve available for  Wind Available forfShore
-      power plants; this amount is the maximum available for the grid operator considering
-      the commitment decisions taken by the model
-    unit: MWh
-- Reserve|Electricity|Frequency Containment|Energy Storage System:
-    description: Frequency Containment Reserve available for energy storage systems,
-      excl. hydro storage; this amount is the maximum available for the grid operator
-      considering the commitment decisions taken by the model
-    unit: MWh
+
+- Reserve|Electricity|Automatic Frequency Restoration|<Fuel>:
+    description: Automatic Frequency Restoration Reserve available for <Fuel>
+     power plants; this amount is the maximum available for the grid operator considering
+     the commitment decisions taken by the model
+    unit:
+    - GWh
+    skip-region-aggregation: false
+
+- Reserve|Electricity|Frequency Containment|<Fuel>:
+    description: Frequency Containment Reserve available for <Fuel>
+     power plants; this amount is the maximum available for the grid operator considering
+     the commitment decisions taken by the model
+    unit:
+    - GWh
+    skip-region-aggregation: false
+
 - Marginal Cost|CO2 Emissions|Electricity:
     description: Marginal Cost associated to the constraint in terms of CO2 emissions
       by the electricity power sector

--- a/definitions/variable/technology/electricity-operation.yaml
+++ b/definitions/variable/technology/electricity-operation.yaml
@@ -12,8 +12,8 @@
 #   - Flows in transmission lines
 # Demand not served
 
-- Active Power|Electricity|<Fuel>:
-    description: Active power of <Fuel> power plants
+- Active Power|Electricity|<Electricity Input>:
+    description: Active power of <Electricity Input> power plants
     unit: GWh
 
 - Active Power|Electricity|Load Curtailment:
@@ -41,21 +41,21 @@
     unit: MWh
     - GWh
 
-- Operation Cost|Electricity|<Fuel>:
-    description: Operation Cost of <Fuel> power plants
+- Operation Cost|Electricity|<Electricity Input>:
+    description: Operation Cost of <Electricity Input> power plants
     unit: EUR_2020
     skip-region-aggregation: true
 
-- Reserve|Electricity|Automatic Frequency Restoration|<Fuel>:
-    description: Automatic Frequency Restoration Reserve available for <Fuel>
+- Reserve|Electricity|Automatic Frequency Restoration|<Electricity Input>:
+    description: Automatic Frequency Restoration Reserve available for <Electricity Input>
      power plants; this amount is the maximum available for the grid operator considering
      the commitment decisions taken by the model
     unit:
     - GWh
     skip-region-aggregation: false
 
-- Reserve|Electricity|Frequency Containment|<Fuel>:
-    description: Frequency Containment Reserve available for <Fuel>
+- Reserve|Electricity|Frequency Containment|<Electricity Input>:
+    description: Frequency Containment Reserve available for <Electricity Input>
      power plants; this amount is the maximum available for the grid operator considering
      the commitment decisions taken by the model
     unit:

--- a/definitions/variable/technology/power-plant.yaml
+++ b/definitions/variable/technology/power-plant.yaml
@@ -112,14 +112,10 @@
     skip-region-aggregation: true
 - Maximum Storage|Electricity|Hydro|Reservoir:
     description: Maximum volume of a reservoir expressed in energy
-    unit:
-    - MWh
-    - GWh
+    unit: GWh
 - Minimum Storage|Electricity|Hydro|Reservoir:
     description: Minimum volume of a reservoir expressed in energy
-    unit:
-    - MWh
-    - GWh
+    unit: GWh
 - Pumping Efficiency|Electricity|Hydro|Reservoir:
     description: Efficiency of pumping for a hydro reservoir power plant
     unit: '%'
@@ -130,37 +126,25 @@
     skip-region-aggregation: true
 - Inflows|Electricity|Hydro|Reservoir:
     description: Inflows into a reservoir expressed in energy
-    unit:
-    - MWh
-    - GWh
+    unit: GWh
 - Initial Storage Level|Electricity|Hydro|Pumped Storage:
     description: This is the amount of stored energy in the storage of a pumped-storage
       hydro unit at the beginning of the first hour into a time series with hourly
       steps.
-    unit:
-    - MWh
-    - GWh
+    unit: GWh
 - Maximum Charge|Electricity|Hydro|Pumped Storage:
     description: Maximum charge when storing energy in the pumped-storage hydro unit.
-    unit:
-    - MW
-    - GW
+    unit: GW
 - Maximum Discharge|Electricity|Hydro|Pumped Storage:
     description: Maximum discharge when consuming energy from the pumped-storage hydro
       unit.
-    unit:
-    - MW
-    - GW
+    unit: GW
 - Maximum Storage|Electricity|Hydro|Pumped Storage:
     description: Maximum volume of a pumped-storage hydro unit expressed in energy
-    unit:
-    - MWh
-    - GWh
+    unit: GWh
 - Minimum Storage|Electricity|Hydro|Pumped Storage:
     description: Minimum volume of a pumped-storage hydro unit expressed in energy
-    unit:
-    - MWh
-    - GWh
+    unit: GWh
 - Pumping Efficiency|Electricity|Hydro|Pumped Storage:
     description: Efficiency of pumping for a pumped-storage hydro unit
     unit: '%'
@@ -188,47 +172,31 @@
 - Maximum Energy Charge|Electricity|Energy Storage System:
     description: This is the upper bound that energy storage system could charge energy
       at time "t".
-    unit:
-    - MWh
-    - GWh
+    unit: GWh
 - Initial Storage Level|Electricity|Energy Storage System:
     description: Initial energy stored in the energy storage system unit at first
       load level. (ESS that includes hydro, battery, etc.)
-    unit:
-    - MWh
-    - GWh
+    unit: GWh
 - Maximum Charge|Electricity|Energy Storage System:
     description: Maximum charge when storing energy the energy storage system unit.
-    unit:
-    - MW
-    - GW
+    unit: GW
 - Maximum Discharge|Electricity|Energy Storage System:
     description: Maximum discharge when consuming energy from the energy storage system
       unit.
-    unit:
-    - MW
-    - GW
+    unit: GW
 - Maximum Storage|Electricity|Energy Storage System:
     description: Maximum energy that can be stored by the energy storage systems.
-    unit:
-    - MWh
-    - GWh
+    unit: GWh
 - Maximum Storage|Electricity|Energy Storage System|Lithium-Ion:
     description: Maximum energy that can be stored by the Lithium Iron Batteries systems.
-    unit:
-    - MWh
-    - GWh
+    unit: GWh
 - Maximum Storage|Electricity|Energy Storage System|Redox Flow:
     description: Maximum energy that can be stored by the Redox Flow Batteries systems.
-    unit:
-    - MWh
-    - GWh
+    unit: GWh
 - Maximum Storage|Electricity|Energy Storage System|Compressed Air:
     description: Maximum energy that can be stored by the Compressed air energy storages
       systems.
-    unit:
-    - MWh
-    - GWh
+    unit: GWh
 - Minimum Storage|Electricity|Energy Storage System:
     description: Minimum energy that can be stored by the energy storage system unit.
     unit:

--- a/definitions/variable/technology/power-plant.yaml
+++ b/definitions/variable/technology/power-plant.yaml
@@ -4,110 +4,110 @@
 # linear   term cost   [EUR/GWh] = Linear Var Cost [Mcal/MWh] * Price|Primary Energy [EUR/Mcal] + Operation and Maintenance Variable Cost [EUR/MWh] * 1e-3
 # constant term cost   [EUR/h]   = Constant Var Cost [Mcal/h] * Price|Primary Energy [EUR/Mcal]
 
-- Operational Cost|Constant Term|Electricity Generation|<Fuel>:
+- Operational Cost|Constant Term|Electricity Generation|<Electricity Input>:
     description: Constant term (intercept) to compute operational cost for generating
-      electricity from <Fuel>
+      electricity from <Electricity Input>
     unit: Mcal/hour
     skip-region-aggregation: true
-- Operational Cost|Linear Term|Electricity Generation|<Fuel>:
+- Operational Cost|Linear Term|Electricity Generation|<Electricity Input>:
     description: Linear term (slope) to compute operational cost for generating electricity
-      from <Fuel>
+      from <Electricity Input>
     unit: Mcal/MWh
     skip-region-aggregation: true
-- Operation and Maintenance Cost|Electricity|<Fuel>:
-    description: Operation and maintenance cost for generating electricity from <Fuel>
+- Operation and Maintenance Cost|Electricity|<Electricity Input>:
+    description: Operation and maintenance cost for generating electricity from <Electricity Input>
     unit: EUR/MWh
     skip-region-aggregation: true
-- Shut-Down Cost|Electricity|<Fuel>:
+- Shut-Down Cost|Electricity|<Electricity Input>:
     description: Shutdown cost for a typical power plant generating electricity from
-      <Fuel>
+      <Electricity Input>
     unit: EUR
     skip-region-aggregation: true
-- Start-Up Cost|Electricity|<Fuel>:
+- Start-Up Cost|Electricity|<Electricity Input>:
     description: Startup cost for a typical power plant generating electricity from
-      <Fuel>
+      <Electricity Input>
     unit: EUR
     skip-region-aggregation: true
-- Variable Cost|Electricity|<Fuel>:
-    description: Variable cost for generating electricity from <Fuel>
+- Variable Cost|Electricity|<Electricity Input>:
+    description: Variable cost for generating electricity from <Electricity Input>
     unit: EUR/MWh
     skip-region-aggregation: true
-- Number of Units|Electricity|<Fuel>:
-    description: Number of power plant units generating electricity from <Fuel>
+- Number of Units|Electricity|<Electricity Input>:
+    description: Number of power plant units generating electricity from <Electricity Input>
     unit:
-- Maximum Active Power|Electricity|<Fuel>:
+- Maximum Active Power|Electricity|<Electricity Input>:
     description: Maximum active power of a typical power plant generating electricity
-      from <Fuel>
+      from <Electricity Input>
     unit: MW
-- Minimum On Duration|Electricity|<Fuel>:
+- Minimum On Duration|Electricity|<Electricity Input>:
     description: Minimum duration that a typical power plant generating electricity
-      from <Fuel> has to remain online after start-up
+      from <Electricity Input> has to remain online after start-up
     unit: hour
     skip-region-aggregation: true
-- Minimum Off Duration|Electricity|<Fuel>:
+- Minimum Off Duration|Electricity|<Electricity Input>:
     description: Minimum duration that a typical power plant generating electricity
-      from <Fuel> has to remain offline after shut-down
+      from <Electricity Input> has to remain offline after shut-down
     unit: hour
     skip-region-aggregation: true
-- Forced Outage Rate|Electricity|<Fuel>:
+- Forced Outage Rate|Electricity|<Electricity Input>:
     description: Unavailability as a share relative to Maximum Active Power due to
       unexpected outages (e.g., failures) of a typical power plant generating electricity
-      from <Fuel>
+      from <Electricity Input>
     note: A value of 50 (%) means that the plant can generate at half of maximum active
       power (~installed capacity) during an outage. If the outage rate is lower than
       the level of minimum active power, the plant has to be shut down for the duration
       of the outage.
     unit: '%'
     skip-region-aggregation: true
-- Planned Outage Rate|Electricity|<Fuel>:
+- Planned Outage Rate|Electricity|<Electricity Input>:
     description: Unavailability as a share relative to Maximum Active Power due to
       planned outages (e.g., maintaince, revision) of a typical power plant generating
-      electricity from <Fuel>
+      electricity from <Electricity Input>
     note: A value of 50 (%) means that the plant can generate at half of maximum active
       power (~installed capacity) during an outage. If the outage rate is lower than
       the level of minimum active power, the plant has to be shut down for the duration
       of the outage.
     unit: '%'
     skip-region-aggregation: true
-- Mean Outage Duration|Electricity|<Fuel>:
+- Mean Outage Duration|Electricity|<Electricity Input>:
     description: Mean duration of an outage of a typical power plant generating electricity
-      from <Fuel>
+      from <Electricity Input>
     unit:
     - day
     - hour
     skip-region-aggregation: true
-- Inertia|Electricity|<Fuel>:
+- Inertia|Electricity|<Electricity Input>:
     description: Inertia provided to the system by a typical power plant generating
-      electricity from <Fuel>
+      electricity from <Electricity Input>
     unit: second
     skip-region-aggregation: true
-- Frequency Containment Reserve|Electricity|<Fuel>:
+- Frequency Containment Reserve|Electricity|<Electricity Input>:
     description: Share of Maximum Active Power that can be committed to Frequency
-      Containment Reserve by a typical power plant generating electricity from <Fuel>
+      Containment Reserve by a typical power plant generating electricity from <Electricity Input>
     unit: '%'
     skip-region-aggregation: true
-- Automatic Frequency Restoration Reserve|Electricity|<Fuel>:
+- Automatic Frequency Restoration Reserve|Electricity|<Electricity Input>:
     description: Share of Maximum Active Power that can be committed to Automatic
       Frequency Restoration Reserve by a typical power plant generating electricity
-      from <Fuel>
+      from <Electricity Input>
     unit: '%'
     skip-region-aggregation: true
-- Operating Reserve|Up|Electricity|<Fuel>:
+- Operating Reserve|Up|Electricity|<Electricity Input>:
     description: Upwards operating reserve by a typical power plant generating electricity
-      from <Fuel>
+      from <Electricity Input>
     unit: MWh
-- Operating Reserve|Down|Electricity|<Fuel>:
+- Operating Reserve|Down|Electricity|<Electricity Input>:
     description: Downward operating reserve by a typical power plant generating electricity
-      from <Fuel>
+      from <Electricity Input>
     unit: MWh
-- Maximum Ramping|Up|Electricity|<Fuel>:
+- Maximum Ramping|Up|Electricity|<Electricity Input>:
     description: Upward ramp limit by a typical power plant generating electricity
-      from <Fuel>
+      from <Electricity Input>
     unit: MW/h
     skip-region-aggregation: true
-- Maximum Ramping|Down|Electricity|<Fuel>:
+- Maximum Ramping|Down|Electricity|<Electricity Input>:
     description: Downward ramp limit by a typical power plant generating electricity
-      from <Fuel>
+      from <Electricity Input>
     unit: MW/h
     skip-region-aggregation: true
 - Maximum Storage|Electricity|Hydro|Reservoir:

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -78,148 +78,20 @@
     description: Investment in CO2 transport and storage (note that investment in
       the capturing equipment should be included along with the power plant technology)
     unit: [million EUR_2020/yr, billion USD_2010/yr]
+
 - Investment|Energy Supply|Electricity:
     description: Investments into electricity generation and supply (including electricity
       storage and transmission & distribution)
     unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Biomass:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
+
+- Investment|Energy Supply|Electricity|<Electricity Input>:
+    description: Investments in new <Electricity Input> power generation capacity
+    notes: For plants with CCS, the investment in the capturing equipment should be
+      included but not the one on transport and storage.
     unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Biomass|w/ CCS:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Biomass|w/o CCS:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Coal:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Coal|w/ CCS:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Coal|w/o CCS:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Electricity Storage:
-    description: Investments in electricity storage technologies (e.g., batteries,
-      compressed air storage reservoirs, etc.)
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Fossil:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Gas:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Gas|w/ CCS:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Gas|w/o CCS:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Geothermal:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Hydro:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Non-Biomass Renewables:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Non-fossil:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Nuclear:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Ocean:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Oil:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Oil|w/ CCS:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Oil|w/o CCS:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Other:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Solar:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
+
 - Investment|Energy Supply|Electricity|Transmission and Distribution:
     description: Investments in transmission and distribution of power generation
-    unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Supply|Electricity|Wind:
-    description: Investments in new power generation for the specified power plant
-      category. If the model features several sub-categories, the total investments
-      should be reported. For plants equipped with CCS, the investment in the capturing
-      equipment should be included but not the one on transport and storage.
     unit: [million EUR_2020/yr, billion USD_2010/yr]
 - Investment|Energy Supply|Extraction|Coal:
     description: Investments for extraction and conversion of coal. These should include

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -39,8 +39,8 @@
     description: Capital cost for passenger <Transport>
     unit: [EUR_2020/pkm, USD_2010/pkm]
     skip-region-aggregation: true
-- Fixed Cost|Electricity|<Fuel>:
-    description: Fixed O&M cost for <Fuel>
+- Fixed Cost|Electricity|<Electricity Input>:
+    description: Fixed O&M cost for <Electricity Input>
     unit: [EUR_2020/kW/yr, USD_2010/kW/yr]
     skip-region-aggregation: true
 - Fixed Cost|Heat|Residential and Commercial|<Fuel>:

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -19,8 +19,8 @@
     description: Total installed heat generation capacity for the industrial sector
       from <Fuel>
     unit: GW
-- Capital Cost|Electricity|<Fuel>:
-    description: Capital cost for <Fuel>
+- Capital Cost|Electricity|<Electricity Input>:
+    description: Capital cost for <Electricity Input>
     unit: [EUR_2020/kW, USD_2010/kW]
     skip-region-aggregation: true
 - Capital Cost|Heat|Residential and Commercial|<Fuel>:

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -1,8 +1,8 @@
 - Capacity|Electricity:
     description: Total installed electricity generation capacity
     unit: GW
-- Capacity|Electricity|<Fuel>:
-    description: Total installed electricity generation capacity from <Fuel>
+- Capacity|Electricity|<Electricity Input>:
+    description: Total installed electricity generation capacity from <Electricity Input>
     unit: GW
 - Capacity|Heat|Residential and Commercial:
     description: Total installed heat generation capacity for the residential and


### PR DESCRIPTION
This PR extracts and implements several simplifications from #125, in particular:

 - split the list of fuels into one list of energy carriers specific to the power sector (including nuclear, non-biomass renewables, etc.) and a shorter list of generic fuels (used for heat, etc.)
 - refactor all power-sector-related variables to the new tag-list
 - harmonize units and remove units at alternative orders of magnitude (MWh & GWh)

Due to the harmonization, a number of fuels were renamed (or spelling mistakes were corrected):

- Biomass|New and imported -> Biomass|New and Imported (capital i)
- Lignite-> Coal|Lignite (there is also a corresponding Coal|Hard Coal category)
- Hydro|Ocean -> Ocean
- Wind|OnShore -> Wind|Onshore
- Wind|OffShore -> Wind|Offshore
