### PR TITLE
Euro calliope native regions and mapping

### DIFF
--- a/definitions/region/model_native_regions/euro-calliope_2.0.yaml
+++ b/definitions/region/model_native_regions/euro-calliope_2.0.yaml
@@ -1,3 +1,5 @@
+# The model documentation for Euro-Calliope 2.0 can be found at https://sentinel.energy/wp-content/uploads/2021/03/D4.2-EC.pdf (pp. 9-32)
+# Further details are provided at https://papers.ssrn.com/sol3/papers.cfm?abstract_id=4012180 and https://github.com/calliope-project/euro-calliope-2.0
 - Euro-Calliope 2.0:
   - Euro-Calliope 2.0|Austria
   - Euro-Calliope 2.0|Belgium

--- a/definitions/region/model_native_regions/euro-calliope_2.0.yaml
+++ b/definitions/region/model_native_regions/euro-calliope_2.0.yaml
@@ -1,0 +1,36 @@
+- Euro-Calliope 2.0:
+  - Euro-Calliope 2.0|Austria
+  - Euro-Calliope 2.0|Belgium
+  - Euro-Calliope 2.0|Bulgaria
+  - Euro-Calliope 2.0|Croatia
+  - Euro-Calliope 2.0|Cyprus
+  - Euro-Calliope 2.0|Czech Republic
+  - Euro-Calliope 2.0|Denmark
+  - Euro-Calliope 2.0|Estonia
+  - Euro-Calliope 2.0|Finland
+  - Euro-Calliope 2.0|France
+  - Euro-Calliope 2.0|Germany
+  - Euro-Calliope 2.0|Greece
+  - Euro-Calliope 2.0|Hungary
+  - Euro-Calliope 2.0|Ireland
+  - Euro-Calliope 2.0|Italy
+  - Euro-Calliope 2.0|Latvia
+  - Euro-Calliope 2.0|Lithuania
+  - Euro-Calliope 2.0|Luxembourg
+  - Euro-Calliope 2.0|Netherlands
+  - Euro-Calliope 2.0|Poland
+  - Euro-Calliope 2.0|Portugal
+  - Euro-Calliope 2.0|Romania
+  - Euro-Calliope 2.0|Slovakia
+  - Euro-Calliope 2.0|Slovenia
+  - Euro-Calliope 2.0|Spain
+  - Euro-Calliope 2.0|Sweden
+  - Euro-Calliope 2.0|United Kingdom
+  - Euro-Calliope 2.0|Iceland
+  - Euro-Calliope 2.0|Norway
+  - Euro-Calliope 2.0|Switzerland
+  - Euro-Calliope 2.0|Albania
+  - Euro-Calliope 2.0|Bosnia and Herzegovina
+  - Euro-Calliope 2.0|Northern Macedonia
+  - Euro-Calliope 2.0|Montenegro
+  - Euro-Calliope 2.0|Serbia

--- a/mappings/euro-calliope_2.0.yaml
+++ b/mappings/euro-calliope_2.0.yaml
@@ -1,0 +1,131 @@
+model: Euro-Calliope 2.0
+native_regions:
+  - Austria: Euro-Calliope 2.0|Austria
+  - Belgium: Euro-Calliope 2.0|Belgium
+  - Bulgaria: Euro-Calliope 2.0|Bulgaria
+  - Croatia: Euro-Calliope 2.0|Croatia
+  - Cyprus: Euro-Calliope 2.0|Cyprus
+  - Czech Republic: Euro-Calliope 2.0|Czech Republic
+  - Denmark: Euro-Calliope 2.0|Denmark
+  - Estonia: Euro-Calliope 2.0|Estonia
+  - Finland: Euro-Calliope 2.0|Finland
+  - France: Euro-Calliope 2.0|France
+  - Germany: Euro-Calliope 2.0|Germany
+  - Greece: Euro-Calliope 2.0|Greece
+  - Hungary: Euro-Calliope 2.0|Hungary
+  - Ireland: Euro-Calliope 2.0|Ireland
+  - Italy: Euro-Calliope 2.0|Italy
+  - Latvia: Euro-Calliope 2.0|Latvia
+  - Lithuania: Euro-Calliope 2.0|Lithuania
+  - Luxembourg: Euro-Calliope 2.0|Luxembourg
+  - Netherlands: Euro-Calliope 2.0|Netherlands
+  - Poland: Euro-Calliope 2.0|Poland
+  - Portugal: Euro-Calliope 2.0|Portugal
+  - Romania: Euro-Calliope 2.0|Romania
+  - Slovakia: Euro-Calliope 2.0|Slovakia
+  - Slovenia: Euro-Calliope 2.0|Slovenia
+  - Spain: Euro-Calliope 2.0|Spain
+  - Sweden: Euro-Calliope 2.0|Sweden
+  - United Kingdom: Euro-Calliope 2.0|United Kingdom
+  - Iceland: Euro-Calliope 2.0|Iceland
+  - Norway: Euro-Calliope 2.0|Norway
+  - Switzerland: Euro-Calliope 2.0|Switzerland
+  - Albania: Euro-Calliope 2.0|Albania
+  - Bosnia and Herzegovina: Euro-Calliope 2.0|Bosnia and Herzegovina
+  - Northern Macedonia: Euro-Calliope 2.0|Northern Macedonia
+  - Montenegro: Euro-Calliope 2.0|Montenegro
+  - Serbia: Euro-Calliope 2.0|Serbia
+common_regions:
+  - EU27 (excl. Malta):
+    - Austria
+    - Belgium
+    - Bulgaria
+    - Croatia
+    - Cyprus
+    - Czech Republic
+    - Denmark
+    - Estonia
+    - Finland
+    - France
+    - Germany
+    - Greece
+    - Hungary
+    - Ireland
+    - Italy
+    - Latvia
+    - Lithuania
+    - Luxembourg
+    - Netherlands
+    - Poland
+    - Portugal
+    - Romania
+    - Slovakia
+    - Slovenia
+    - Spain
+    - Sweden
+    - Iceland
+  - EU27+UK (excl.Malta):
+    - Austria
+    - Belgium
+    - Bulgaria
+    - Croatia
+    - Cyprus
+    - Czech Republic
+    - Denmark
+    - Estonia
+    - Finland
+    - France
+    - Germany
+    - Greece
+    - Hungary
+    - Ireland
+    - Italy
+    - Latvia
+    - Lithuania
+    - Luxembourg
+    - Netherlands
+    - Poland
+    - Portugal
+    - Romania
+    - Slovakia
+    - Slovenia
+    - Spain
+    - Sweden
+    - Iceland
+    - United Kingdom
+  - Europe:
+    - Austria
+    - Belgium
+    - Bulgaria
+    - Croatia
+    - Cyprus
+    - Czech Republic
+    - Denmark
+    - Estonia
+    - Finland
+    - France
+    - Germany
+    - Greece
+    - Hungary
+    - Ireland
+    - Italy
+    - Latvia
+    - Lithuania
+    - Luxembourg
+    - Netherlands
+    - Poland
+    - Portugal
+    - Romania
+    - Slovakia
+    - Slovenia
+    - Spain
+    - Sweden
+    - United Kingdom
+    - Iceland
+    - Norway
+    - Switzerland
+    - Albania
+    - Bosnia and Herzegovina
+    - Northern Macedonia
+    - Montenegro
+    - Serbia

--- a/mappings/euro-calliope_2.0.yaml
+++ b/mappings/euro-calliope_2.0.yaml
@@ -65,7 +65,7 @@ common_regions:
     - Spain
     - Sweden
     - Iceland
-  - EU27+UK:
+  - EU27 & UK:
     - Austria
     - Belgium
     - Bulgaria

--- a/mappings/euro-calliope_2.0.yaml
+++ b/mappings/euro-calliope_2.0.yaml
@@ -1,3 +1,4 @@
+# Aggregate regions for Europe (such as EU27 and EU27+UK) do not include Malta
 model: Euro-Calliope 2.0
 native_regions:
   - Austria: Euro-Calliope 2.0|Austria
@@ -36,7 +37,7 @@ native_regions:
   - Montenegro: Euro-Calliope 2.0|Montenegro
   - Serbia: Euro-Calliope 2.0|Serbia
 common_regions:
-  - EU27 (excl. Malta):
+  - EU27:
     - Austria
     - Belgium
     - Bulgaria
@@ -64,7 +65,7 @@ common_regions:
     - Spain
     - Sweden
     - Iceland
-  - EU27+UK (excl.Malta):
+  - EU27+UK:
     - Austria
     - Belgium
     - Bulgaria


### PR DESCRIPTION
Following the indications provided in "ECEMF T1.1 Model Diagnostic Exercise – Protocol v2.0", I have added Euro-Calliope 2.0's native regions and their mapping to larger aggregate groups of regions (e.g. EU27). The names I am using for regions in the YAML files in this pull request are the same I am using for the upload in the ECEMF's Scenario Explorer.