### PR TITLE
Refactor <Tag> to {Tag} for compatbility with nomenclature 0.2

### DIFF
--- a/definitions/variable/economy/README.md
+++ b/definitions/variable/economy/README.md
@@ -12,7 +12,7 @@ See [economy.yaml](economy.yaml) for the full codelist.
 The discount rate should be distinguished by sector or (group of) firms
 and follow the structure below.
 
-- `Discount rate|<Sub-Category>`
+- `Discount rate|{Sub-Category}`
 
 For models assuming a social welfare maximization with a unique discount rate,
 please use `Discount rate|Social`.  
@@ -22,7 +22,7 @@ please use `Discount rate|Social`.
 The variables for population should follow the structure below.
 
 - `Population`
-- `Population|<Specification>`
+- `Population|{Specification}`
 
 Specifications can be linked to demographic characteristics (e.g., urban vs.
 rural) or socio-economic aspects such as population at risk of hunger.
@@ -33,7 +33,7 @@ The variables for Gross Domestic Product (GDP) should follow the structure
 below, where the method used for aggregation should be either
 market-based exchange rates (MER) or purchasing-power parity (PPP).
 
-- `GDP|<Method>`
+- `GDP|{Method}`
 
 ## Consumption
 
@@ -53,8 +53,8 @@ see the section on variables related to [technologies](../../variable/technology
 for further discussion.
 
 - `Price|Carbon`
-- `Price|<Fuel>`
-- `Price|<Fuel>|<Sector>`
+- `Price|{Fuel}`
+- `Price|{Fuel}|{Sector}`
 
 ## Policy Cost
 
@@ -62,4 +62,4 @@ The variables related to costs from policies (compared to a baseline)
 should follow the structure below. The policies included in the metric and
 the baseline used for comparison must be specified in the scenario protocol. 
 
-- `Policy Cost|<Metric>`
+- `Policy Cost|{Metric}`

--- a/definitions/variable/economy/economy.yaml
+++ b/definitions/variable/economy/economy.yaml
@@ -16,58 +16,58 @@
     description: Total consumption of all goods, by industries in a region
     unit: [billion USD_2010/yr, billion EUR_2020/yr]
 
-- Consumption|Households|<Product>|Imported:
-    description: Consumption of imported <Product> by households
+- Consumption|Households|{Product}|Imported:
+    description: Consumption of imported {Product} by households
     unit: [billion USD_2010/yr, billion EUR_2020/yr]
 
-- Consumption|Households|<Product>|Domestic:
-    description: Consumption of domestic <Product> by households
+- Consumption|Households|{Product}|Domestic:
+    description: Consumption of domestic {Product} by households
     unit: [billion USD_2010/yr, billion EUR_2020/yr]
 
-- Consumption|Government|<Product>|Imported:
-    description: Consumption of imported <Product> by government
+- Consumption|Government|{Product}|Imported:
+    description: Consumption of imported {Product} by government
     unit: [billion USD_2010/yr, billion EUR_2020/yr]
 
-- Consumption|Government|<Product>|Domestic:
-    description: Consumption of domestic <Product> by government
+- Consumption|Government|{Product}|Domestic:
+    description: Consumption of domestic {Product} by government
     unit: [billion USD_2010/yr, billion EUR_2020/yr]
 
-- Consumption|Gross Capital Formation|<Product>|Imported:
-    description: Consumption of imported <Product> by gross capital formation
+- Consumption|Gross Capital Formation|{Product}|Imported:
+    description: Consumption of imported {Product} by gross capital formation
     unit: [billion USD_2010/yr, billion EUR_2020/yr]
 
-- Consumption|Gross Capital Formation|<Product>|Domestic:
-    description: Consumption of domestic <Product> by gross capital formation
+- Consumption|Gross Capital Formation|{Product}|Domestic:
+    description: Consumption of domestic {Product} by gross capital formation
     unit: [billion USD_2010/yr, billion EUR_2020/yr]
 
-- Consumption|Industry|<Product>|Imported:
-    description: Consumption of imported <Product> by industries
+- Consumption|Industry|{Product}|Imported:
+    description: Consumption of imported {Product} by industries
     unit: [billion USD_2010/yr, billion EUR_2020/yr]
 
-- Consumption|Industry|<Product>|Domestic:
-    description: Consumption of domestic <Product> by industries
+- Consumption|Industry|{Product}|Domestic:
+    description: Consumption of domestic {Product} by industries
     unit: [billion USD_2010/yr, billion EUR_2020/yr]
 
-- Output|Industry|<Industry>:
-    description: Total monetary value of production (output) by <Industry>.
+- Output|Industry|{Industry}:
+    description: Total monetary value of production (output) by {Industry}.
       The value includes cost of production, capital costs, labor costs and taxes.
     unit: [billion USD_2010/yr, billion EUR_2020/yr]
 
-- Output|Product|<Product>:
-    description: Total monetary value of <Product> produced (output) and sold
+- Output|Product|{Product}:
+    description: Total monetary value of {Product} produced (output) and sold
       to industry, households and government
     unit: [billion USD_2010/yr, billion EUR_2020/yr]
 
-- Capital|<Industry>:
-    description: Total capital costs spend by <Industry>
+- Capital|{Industry}:
+    description: Total capital costs spend by {Industry}
     unit: [billion USD_2010/yr, billion EUR_2020/yr]
 
-- Labor|<Industry>:
-    description: Total wages spent by <Industry>
+- Labor|{Industry}:
+    description: Total wages spent by {Industry}
     unit: [billion USD_2010/yr, billion EUR_2020/yr]
 
-- Product Price Index|<Product>:
-    description: Price index on <Product> level, relative to base year 2011
+- Product Price Index|{Product}:
+    description: Price index on {Product} level, relative to base year 2011
     note: The index equals 1 in 2011, the reference year
     unit: index
     skip-region-aggregation: true

--- a/definitions/variable/emissions/README.md
+++ b/definitions/variable/emissions/README.md
@@ -8,8 +8,8 @@ carbon sequestration and the impact of emissions on the climate
 
 Variables related to emissions should follow the structure below.
 
-- `Emissions|<Species>`
-- `Emissions|<Species>|<Specification>`
+- `Emissions|{Species}`
+- `Emissions|{Species}|{Specification}`
 
 Examples of species: `CO2`, `CH4`, `CO`, `NOx`
 
@@ -25,14 +25,14 @@ subcategories:
 
 Variables in this category should follow the structure below.
 
-- `Carbon Sequestration|<Type>`
-- `Carbon Sequestration|<Type>|<Specification>`
+- `Carbon Sequestration|{Type}`
+- `Carbon Sequestration|{Type}|{Specification}`
 
 ## Temperature
 
 Variables in this category should follow the structure below.
 
-- `Temperature|<Specification>`
+- `Temperature|{Specification}`
 
 ## Codelist
 

--- a/definitions/variable/emissions/emissions.yaml
+++ b/definitions/variable/emissions/emissions.yaml
@@ -265,8 +265,8 @@
     description: CO2 emissions from agriculture, forestry and other land use (IPCC
       category 3)
     unit: Mt CO2/yr
-- Emission Rate|CO2|Electricity|<Electricity Input>:
-    description: CO2 emissions of a <Electricity Input> power plant
+- Emission Rate|CO2|Electricity|{Electricity Input}:
+    description: CO2 emissions of a {Electricity Input} power plant
     unit: tons/MWh
     skip-region-aggregation: true
 - Emissions|CO2|Energy:

--- a/definitions/variable/energy/README.md
+++ b/definitions/variable/energy/README.md
@@ -11,8 +11,8 @@ of energy/fuels from renewables.
 The hierarchy of variables in this group should follow this style:
 
 - `Primary Energy`
-- `Primary Energy|<Fuel>`
-- `Primary Energy|<Fuel>|<Specification>`
+- `Primary Energy|{Fuel}`
+- `Primary Energy|{Fuel}|{Specification}`
 
 See [energy-primary.yaml](energy-primary.yaml) for the full codelist.
 
@@ -24,7 +24,7 @@ The hierarchy of variables in this group should follow this style:
 
 - `Secondary Energy|<Output Fuel>`
 - `Secondary Energy|<Output Fuel>|<Input Fuel>`
-- `Secondary Energy|<Output Fuel>|<Input Fuel>|<Specification>`
+- `Secondary Energy|<Output Fuel>|<Input Fuel>|{Specification}`
 
 See [energy-secondary.yaml](energy-secondary.yaml) for the full codelist.
 
@@ -38,15 +38,15 @@ and a by-uses dimension (uses=transportation, heating, industrial process...)
 The hierarchy of variables in this group should follow this style:
 
 - `Final Energy`
-- `Final Energy|<Fuel>`
-- `Final Energy|<Fuel>|<Specification>`
-- `Final Energy|<Sector>`
-- `Final Energy|<Sector>|<Specification>`
-- `Final Energy|<Sector>|<Fuel>|<Specification>`
+- `Final Energy|{Fuel}`
+- `Final Energy|{Fuel}|{Specification}`
+- `Final Energy|{Sector}`
+- `Final Energy|{Sector}|{Specification}`
+- `Final Energy|{Sector}|{Fuel}|{Specification}`
 
 To avoid overlap of variable definitions, data reported at the level
 of sector *and* fuel, the variable should follow the convention
-`Final Energy|<Sector>|<Fuel>|<Specification>`
-(not `Final Energy|<Fuel>|<Sector>|<Specification>`).
+`Final Energy|{Sector}|{Fuel}|{Specification}`
+(not `Final Energy|{Fuel}|{Sector}|{Specification}`).
 
 See [energy-final.yaml](energy-final.yaml) for the full codelist.

--- a/definitions/variable/energy/energy-secondary.yaml
+++ b/definitions/variable/energy/energy-secondary.yaml
@@ -7,8 +7,8 @@
 - Secondary Energy|Electricity:
     description: Total net electricity production
     unit: EJ/yr
-- Secondary Energy|Electricity|<Electricity Input>:
-    description: Net electricity production from <Electricity Input>
+- Secondary Energy|Electricity|{Electricity Input}:
+    description: Net electricity production from {Electricity Input}
     unit: EJ/yr
 - Secondary Energy|Electricity|Curtailment:
     description: Curtailment of electricity production due to oversupply from
@@ -29,14 +29,14 @@
 - Secondary Energy|Heat:
     description: Total heat generation
     unit: EJ/yr
-- Secondary Energy|Heat|<Fuel>:
-    description: Total heat generation from <Fuel>
+- Secondary Energy|Heat|{Fuel}:
+    description: Total heat generation from {Fuel}
     unit: EJ/yr
 - Secondary Energy|Hydrogen:
     description: Total hydrogen production
     unit: EJ/yr
-- Secondary Energy|Hydrogen|<Fuel>:
-    description: Hydrogen production from <Fuel>
+- Secondary Energy|Hydrogen|{Fuel}:
+    description: Hydrogen production from {Fuel}
     unit: EJ/yr
 - Secondary Energy|Liquids:
     description: Total production of refined liquid fuels from all energy sources

--- a/definitions/variable/energy/energy-services.yaml
+++ b/definitions/variable/energy/energy-services.yaml
@@ -7,13 +7,13 @@
     description: Provision of energy services related to all freight transportation
       modes
     unit: Gtkm/yr
-- Energy Service|Transportation|Freight|<Transport>:
-    description: Provision of energy services related to freight <Transport>
+- Energy Service|Transportation|Freight|{Transport}:
+    description: Provision of energy services related to freight {Transport}
     unit: Gtkm/yr
 - Energy Service|Transportation|Passenger:
     description: Provision of energy services related to all passenger transportation
       modes
     unit: Gpkm/yr
-- Energy Service|Transportation|Passenger|<Transport>:
-    description: Provision of energy services related to passenger <Transport>
+- Energy Service|Transportation|Passenger|{Transport}:
+    description: Provision of energy services related to passenger {Transport}
     unit: Gpkm/yr

--- a/definitions/variable/tag_electricity_input_types.yaml
+++ b/definitions/variable/tag_electricity_input_types.yaml
@@ -1,9 +1,9 @@
-# This list of inputs will replace any occurrence of `<Electricity Input>`
+# This list of inputs will replace any occurrence of `{Electricity Input}`
 # in a variable-definition yaml file
 
 # This list is intended for use as input fuel to the power sector
 
-- <Electricity Input>:
+- Electricity Input:
   - Biomass:
       description: purpose-grown biomass, crop residues, forest industry waste,
         solid waste from domestic, agricultural or municipal sources

--- a/definitions/variable/tag_fuel_types.yaml
+++ b/definitions/variable/tag_fuel_types.yaml
@@ -1,9 +1,9 @@
-# This list of inputs will replace any occurrence of `<Fuel>`
+# This list of inputs will replace any occurrence of `{Fuel}`
 # in a variable-definition yaml file
 
 # This list is intended for use as fuels except for the power sector
 
-- <Fuel>:
+- Fuel:
   - Biomass:
       description: purpose-grown biomass, crop residues, forest industry waste,
         solid waste from domestic, agricultural or municipal sources

--- a/definitions/variable/tag_industry_types.yaml
+++ b/definitions/variable/tag_industry_types.yaml
@@ -1,11 +1,11 @@
-# This list of industries will replace any occurrence of `<Industry>`
+# This list of industries will replace any occurrence of `{Industry}`
 # in a variable-definition yaml file
 
 #   i.e., The following standard generic structure in economic variables:
-#   Capital Price Index|<Industry>:
-#   Labor Price Index|<Industry>:
+#   Capital Price Index|{Industry}:
+#   Labor Price Index|{Industry}:
 
-- <Industry>:
+- Industry:
   - iAGRI:
       description: agriculture
 

--- a/definitions/variable/tag_product_types.yaml
+++ b/definitions/variable/tag_product_types.yaml
@@ -1,11 +1,11 @@
-# This list of products will replace any occurrence of `<Product>`
+# This list of products will replace any occurrence of `{Product}`
 # in a variable-definition yaml file
 
 #   i.e., The following standard structure in economic variables:
-#   Consumption|Households|<Product>|Imported:
-#   Consumption|Government|<Product>|Domestic:
+#   Consumption|Households|{Product}|Imported:
+#   Consumption|Government|{Product}|Domestic:
 
-- <Product>:
+- Product:
   - pAGRI:
       description: agriculture
 

--- a/definitions/variable/tag_transport_types.yaml
+++ b/definitions/variable/tag_transport_types.yaml
@@ -1,7 +1,7 @@
-# This list of fuels will replace any occurrence of `<Transport>`
+# This list of fuels will replace any occurrence of `{Transport}`
 # in a variable-definition yaml file
 
-- <Transport>:
+- Transport:
   - Maritime:
       description: maritime transportation technologies
 

--- a/definitions/variable/technology/README.md
+++ b/definitions/variable/technology/README.md
@@ -21,26 +21,26 @@ See [technologies.yaml](technologies.yaml) for the full codelist.
 Variables for the installed capacity of (energy) production/generation
 or transmission should follow the structure below.
 
-- `Capacity|<Fuel>`
-- `Capacity|<Fuel>|<Specification>`
-- `Capacity|<Fuel>|<Specification>|<Identifier Of A Specific Power Plant>`
+- `Capacity|{Fuel}`
+- `Capacity|{Fuel}|{Specification}`
+- `Capacity|{Fuel}|{Specification}|{Identifier Of A Specific Power Plant}`
 
 ## Capital Cost
 
 Variables for the overnight capital cost for new construction of power plants
 or tranmission lines should follow the structure below.
 
-- `Capital Cost|<Fuel>|<Specification>`
-- `Capital Cost|<Fuel>|<Specification>|<Identifier Of A Specific Power Plant>`
+- `Capital Cost|{Fuel}|{Specification}`
+- `Capital Cost|{Fuel}|{Specification}|{Identifier Of A Specific Power Plant}`
 
 Note that it usually does not make sense to report capital costs
-at a more aggregate level (i.e., `Capital Cost|<Fuel>`).
+at a more aggregate level (i.e., `Capital Cost|{Fuel}`).
 
 ## Investment expenditure
 
 Variables for the expenditure for new construction of power plants
 or tranmission lines should follow the structure below.
 
-- `Investment|<Type>`
-- `Investment|<Type>|<Fuel>`
-- `Investment|<Type>|<Fuel>|<Specification>`
+- `Investment|{Type}`
+- `Investment|{Type}|{Fuel}`
+- `Investment|{Type}|{Fuel}|{Specification}`

--- a/definitions/variable/technology/electricity-operation.yaml
+++ b/definitions/variable/technology/electricity-operation.yaml
@@ -12,8 +12,8 @@
 #   - Flows in transmission lines
 # Demand not served
 
-- Active Power|Electricity|<Electricity Input>:
-    description: Active power of <Electricity Input> power plants
+- Active Power|Electricity|{Electricity Input}:
+    description: Active power of {Electricity Input} power plants
     unit: GWh
 
 - Active Power|Electricity|Load Curtailment:
@@ -40,20 +40,20 @@
     description: remaining amount of curtailement
     unit: GWh
 
-- Operation Cost|Electricity|<Electricity Input>:
-    description: Operation Cost of <Electricity Input> power plants
+- Operation Cost|Electricity|{Electricity Input}:
+    description: Operation Cost of {Electricity Input} power plants
     unit: EUR_2020
     skip-region-aggregation: true
 
-- Reserve|Electricity|Automatic Frequency Restoration|<Electricity Input>:
-    description: Automatic Frequency Restoration Reserve available for <Electricity Input>
+- Reserve|Electricity|Automatic Frequency Restoration|{Electricity Input}:
+    description: Automatic Frequency Restoration Reserve available for {Electricity Input}
      power plants; this amount is the maximum available for the grid operator considering
      the commitment decisions taken by the model
     unit: GWh
     skip-region-aggregation: false
 
-- Reserve|Electricity|Frequency Containment|<Electricity Input>:
-    description: Frequency Containment Reserve available for <Electricity Input>
+- Reserve|Electricity|Frequency Containment|{Electricity Input}:
+    description: Frequency Containment Reserve available for {Electricity Input}
      power plants; this amount is the maximum available for the grid operator considering
      the commitment decisions taken by the model
     unit: GWh

--- a/definitions/variable/technology/power-plant.yaml
+++ b/definitions/variable/technology/power-plant.yaml
@@ -4,110 +4,110 @@
 # linear   term cost   [EUR/GWh] = Linear Var Cost [Mcal/MWh] * Price|Primary Energy [EUR/Mcal] + Operation and Maintenance Variable Cost [EUR/MWh] * 1e-3
 # constant term cost   [EUR/h]   = Constant Var Cost [Mcal/h] * Price|Primary Energy [EUR/Mcal]
 
-- Operational Cost|Constant Term|Electricity Generation|<Electricity Input>:
+- Operational Cost|Constant Term|Electricity Generation|{Electricity Input}:
     description: Constant term (intercept) to compute operational cost for generating
-      electricity from <Electricity Input>
+      electricity from {Electricity Input}
     unit: Mcal/hour
     skip-region-aggregation: true
-- Operational Cost|Linear Term|Electricity Generation|<Electricity Input>:
+- Operational Cost|Linear Term|Electricity Generation|{Electricity Input}:
     description: Linear term (slope) to compute operational cost for generating electricity
-      from <Electricity Input>
+      from {Electricity Input}
     unit: Mcal/MWh
     skip-region-aggregation: true
-- Operation and Maintenance Cost|Electricity|<Electricity Input>:
-    description: Operation and maintenance cost for generating electricity from <Electricity Input>
+- Operation and Maintenance Cost|Electricity|{Electricity Input}:
+    description: Operation and maintenance cost for generating electricity from {Electricity Input}
     unit: EUR/MWh
     skip-region-aggregation: true
-- Shut-Down Cost|Electricity|<Electricity Input>:
+- Shut-Down Cost|Electricity|{Electricity Input}:
     description: Shutdown cost for a typical power plant generating electricity from
-      <Electricity Input>
+      {Electricity Input}
     unit: EUR
     skip-region-aggregation: true
-- Start-Up Cost|Electricity|<Electricity Input>:
+- Start-Up Cost|Electricity|{Electricity Input}:
     description: Startup cost for a typical power plant generating electricity from
-      <Electricity Input>
+      {Electricity Input}
     unit: EUR
     skip-region-aggregation: true
-- Variable Cost|Electricity|<Electricity Input>:
-    description: Variable cost for generating electricity from <Electricity Input>
+- Variable Cost|Electricity|{Electricity Input}:
+    description: Variable cost for generating electricity from {Electricity Input}
     unit: EUR/MWh
     skip-region-aggregation: true
-- Number of Units|Electricity|<Electricity Input>:
-    description: Number of power plant units generating electricity from <Electricity Input>
+- Number of Units|Electricity|{Electricity Input}:
+    description: Number of power plant units generating electricity from {Electricity Input}
     unit:
-- Maximum Active Power|Electricity|<Electricity Input>:
+- Maximum Active Power|Electricity|{Electricity Input}:
     description: Maximum active power of a typical power plant generating electricity
-      from <Electricity Input>
+      from {Electricity Input}
     unit: MW
-- Minimum On Duration|Electricity|<Electricity Input>:
+- Minimum On Duration|Electricity|{Electricity Input}:
     description: Minimum duration that a typical power plant generating electricity
-      from <Electricity Input> has to remain online after start-up
+      from {Electricity Input} has to remain online after start-up
     unit: hour
     skip-region-aggregation: true
-- Minimum Off Duration|Electricity|<Electricity Input>:
+- Minimum Off Duration|Electricity|{Electricity Input}:
     description: Minimum duration that a typical power plant generating electricity
-      from <Electricity Input> has to remain offline after shut-down
+      from {Electricity Input} has to remain offline after shut-down
     unit: hour
     skip-region-aggregation: true
-- Forced Outage Rate|Electricity|<Electricity Input>:
+- Forced Outage Rate|Electricity|{Electricity Input}:
     description: Unavailability as a share relative to Maximum Active Power due to
       unexpected outages (e.g., failures) of a typical power plant generating electricity
-      from <Electricity Input>
+      from {Electricity Input}
     note: A value of 50 (%) means that the plant can generate at half of maximum active
       power (~installed capacity) during an outage. If the outage rate is lower than
       the level of minimum active power, the plant has to be shut down for the duration
       of the outage.
     unit: '%'
     skip-region-aggregation: true
-- Planned Outage Rate|Electricity|<Electricity Input>:
+- Planned Outage Rate|Electricity|{Electricity Input}:
     description: Unavailability as a share relative to Maximum Active Power due to
       planned outages (e.g., maintaince, revision) of a typical power plant generating
-      electricity from <Electricity Input>
+      electricity from {Electricity Input}
     note: A value of 50 (%) means that the plant can generate at half of maximum active
       power (~installed capacity) during an outage. If the outage rate is lower than
       the level of minimum active power, the plant has to be shut down for the duration
       of the outage.
     unit: '%'
     skip-region-aggregation: true
-- Mean Outage Duration|Electricity|<Electricity Input>:
+- Mean Outage Duration|Electricity|{Electricity Input}:
     description: Mean duration of an outage of a typical power plant generating electricity
-      from <Electricity Input>
+      from {Electricity Input}
     unit:
     - day
     - hour
     skip-region-aggregation: true
-- Inertia|Electricity|<Electricity Input>:
+- Inertia|Electricity|{Electricity Input}:
     description: Inertia provided to the system by a typical power plant generating
-      electricity from <Electricity Input>
+      electricity from {Electricity Input}
     unit: second
     skip-region-aggregation: true
-- Frequency Containment Reserve|Electricity|<Electricity Input>:
+- Frequency Containment Reserve|Electricity|{Electricity Input}:
     description: Share of Maximum Active Power that can be committed to Frequency
-      Containment Reserve by a typical power plant generating electricity from <Electricity Input>
+      Containment Reserve by a typical power plant generating electricity from {Electricity Input}
     unit: '%'
     skip-region-aggregation: true
-- Automatic Frequency Restoration Reserve|Electricity|<Electricity Input>:
+- Automatic Frequency Restoration Reserve|Electricity|{Electricity Input}:
     description: Share of Maximum Active Power that can be committed to Automatic
       Frequency Restoration Reserve by a typical power plant generating electricity
-      from <Electricity Input>
+      from {Electricity Input}
     unit: '%'
     skip-region-aggregation: true
-- Operating Reserve|Up|Electricity|<Electricity Input>:
+- Operating Reserve|Up|Electricity|{Electricity Input}:
     description: Upwards operating reserve by a typical power plant generating electricity
-      from <Electricity Input>
+      from {Electricity Input}
     unit: MWh
-- Operating Reserve|Down|Electricity|<Electricity Input>:
+- Operating Reserve|Down|Electricity|{Electricity Input}:
     description: Downward operating reserve by a typical power plant generating electricity
-      from <Electricity Input>
+      from {Electricity Input}
     unit: MWh
-- Maximum Ramping|Up|Electricity|<Electricity Input>:
+- Maximum Ramping|Up|Electricity|{Electricity Input}:
     description: Upward ramp limit by a typical power plant generating electricity
-      from <Electricity Input>
+      from {Electricity Input}
     unit: MW/h
     skip-region-aggregation: true
-- Maximum Ramping|Down|Electricity|<Electricity Input>:
+- Maximum Ramping|Down|Electricity|{Electricity Input}:
     description: Downward ramp limit by a typical power plant generating electricity
-      from <Electricity Input>
+      from {Electricity Input}
     unit: MW/h
     skip-region-aggregation: true
 - Maximum Storage|Electricity|Hydro|Reservoir:

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -1,70 +1,70 @@
 - Capacity|Electricity:
     description: Total installed electricity generation capacity
     unit: GW
-- Capacity|Electricity|<Electricity Input>:
-    description: Total installed electricity generation capacity from <Electricity Input>
+- Capacity|Electricity|{Electricity Input}:
+    description: Total installed electricity generation capacity from {Electricity Input}
     unit: GW
 - Capacity|Heat|Residential and Commercial:
     description: Total installed heat generation capacity for the residential and
       commercial sectors
     unit: GW
-- Capacity|Heat|Residential and Commercial|<Fuel>:
+- Capacity|Heat|Residential and Commercial|{Fuel}:
     description: Total installed heat generation capacity for the residential and
-      commercial sectors from <Fuel>
+      commercial sectors from {Fuel}
     unit: GW
 - Capacity|Heat|Industrial:
     description: Total installed heat generation capacity for the industrial sector
     unit: GW
-- Capacity|Heat|Industrial|<Fuel>:
+- Capacity|Heat|Industrial|{Fuel}:
     description: Total installed heat generation capacity for the industrial sector
-      from <Fuel>
+      from {Fuel}
     unit: GW
-- Capital Cost|Electricity|<Electricity Input>:
-    description: Capital cost for <Electricity Input>
+- Capital Cost|Electricity|{Electricity Input}:
+    description: Capital cost for {Electricity Input}
     unit: [EUR_2020/kW, USD_2010/kW]
     skip-region-aggregation: true
-- Capital Cost|Heat|Residential and Commercial|<Fuel>:
-    description: Capital cost for <Fuel>
+- Capital Cost|Heat|Residential and Commercial|{Fuel}:
+    description: Capital cost for {Fuel}
     unit: [EUR_2020/kW, USD_2010/kW]
     skip-region-aggregation: true
-- Capital Cost|Heat|Industrial|<Fuel>:
-    description: Capital cost for <Fuel>
+- Capital Cost|Heat|Industrial|{Fuel}:
+    description: Capital cost for {Fuel}
     unit: [EUR_2020/kW, USD_2010/kW]
     skip-region-aggregation: true
-- Capital Cost|Transportation|Freight|<Transport>:
-    description: Capital cost for freight <Transport>
+- Capital Cost|Transportation|Freight|{Transport}:
+    description: Capital cost for freight {Transport}
     unit: [EUR_2020/tkm, USD_2010/tkm]
     skip-region-aggregation: true
-- Capital Cost|Transportation|Passenger|<Transport>:
-    description: Capital cost for passenger <Transport>
+- Capital Cost|Transportation|Passenger|{Transport}:
+    description: Capital cost for passenger {Transport}
     unit: [EUR_2020/pkm, USD_2010/pkm]
     skip-region-aggregation: true
-- Fixed Cost|Electricity|<Electricity Input>:
-    description: Fixed O&M cost for <Electricity Input>
+- Fixed Cost|Electricity|{Electricity Input}:
+    description: Fixed O&M cost for {Electricity Input}
     unit: [EUR_2020/kW/yr, USD_2010/kW/yr]
     skip-region-aggregation: true
-- Fixed Cost|Heat|Residential and Commercial|<Fuel>:
-    description: Fixed O&M for <Fuel>
+- Fixed Cost|Heat|Residential and Commercial|{Fuel}:
+    description: Fixed O&M for {Fuel}
     unit: [EUR_2020/kW/yr, USD_2010/kW/yr]
     skip-region-aggregation: true
-- Fixed Cost|Heat|Industrial|<Fuel>:
-    description: Fixed O&M for <Fuel>
+- Fixed Cost|Heat|Industrial|{Fuel}:
+    description: Fixed O&M for {Fuel}
     unit: [EUR_2020/kW/yr, USD_2010/kW/yr]
     skip-region-aggregation: true
-- Fixed Cost|Transportation|Freight|<Transport>:
-    description: Capital cost for freight <Transport>
+- Fixed Cost|Transportation|Freight|{Transport}:
+    description: Capital cost for freight {Transport}
     unit: [EUR_2020/tkm/yr, USD_2010/tkm/yr]
     skip-region-aggregation: true
-- Fixed Cost|Transportation|Passenger|<Transport>:
-    description: Capital cost for passenger <Transport>
+- Fixed Cost|Transportation|Passenger|{Transport}:
+    description: Capital cost for passenger {Transport}
     unit: [EUR_2020/pkm/yr, USD_2010/pkm/yr]
     skip-region-aggregation: true
-- Variable Cost|Heat|Residential and Commercial|<Fuel>:
-    description: Capital cost for <Fuel>
+- Variable Cost|Heat|Residential and Commercial|{Fuel}:
+    description: Capital cost for {Fuel}
     unit: [EUR_2020/MWh, USD_2010/MWh]
     skip-region-aggregation: true
-- Variable Cost|Heat|Industrial|<Fuel>:
-    description: Capital cost for <Fuel>
+- Variable Cost|Heat|Industrial|{Fuel}:
+    description: Capital cost for {Fuel}
     unit: [EUR_2020/MWh, USD_2010/MWh]
     skip-region-aggregation: true
 - Investment|Energy Efficiency:
@@ -84,8 +84,8 @@
       storage and transmission & distribution)
     unit: [million EUR_2020/yr, billion USD_2010/yr]
 
-- Investment|Energy Supply|Electricity|<Electricity Input>:
-    description: Investments in new <Electricity Input> power generation capacity
+- Investment|Energy Supply|Electricity|{Electricity Input}:
+    description: Investments in new {Electricity Input} power generation capacity
     notes: For plants with CCS, the investment in the capturing equipment should be
       included but not the one on transport and storage.
     unit: [million EUR_2020/yr, billion USD_2010/yr]

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -9,7 +9,7 @@ def test_variables():
 
 
 def test_variables_fuel_types():
-    # check that exploding of <Fuel> to fuels works (including CCS subcategory)
+    # check that exploding of {Fuel} to fuels works (including CCS subcategory)
     obs = definition.variable["Secondary Energy|Electricity|Gas"]
     exp = (
         "Net electricity production from natural gas "
@@ -26,14 +26,14 @@ def test_variables_fuel_types():
 
 
 def test_variables_industry_types():
-    # check that exploding of <industry> to industries works
+    # check that exploding of {industry} to industries works
     obs = definition.variable["Capital|iAGRI"]
     exp = "Total capital costs spend by agriculture"
     assert obs["description"] == exp
 
 
 def test_variables_transport_types():
-    # check that exploding of <transport> to transportation modes works
+    # check that exploding of {transport} to transportation modes works
     obs = definition.variable["Energy Service|Transportation|Freight|Rail"]
     exp = (
         "Provision of energy services related to freight "
@@ -43,7 +43,7 @@ def test_variables_transport_types():
 
 
 def test_variables_product_types():
-    # check that exploding of <product> to procuts works
+    # check that exploding of {product} to products works
     obs = definition.variable["Consumption|Households|pAGRI|Imported"]
     exp = "Consumption of imported agriculture by households"
     assert obs["description"] == exp


### PR DESCRIPTION
This PR is intended to ensure compatibility of release 0.2 of the **nomenclature** and a major change in the tag-format (see https://github.com/IAMconsortium/nomenclature/pull/91).