### PR TITLE
Full country names in OSeMBE upload natives

### DIFF
--- a/definitions/region/model_native_regions/osembe_v1.0.yaml
+++ b/definitions/region/model_native_regions/osembe_v1.0.yaml
@@ -29,3 +29,4 @@
   - OSeMBE v1.0|CHE
   - OSeMBE v1.0|GBR
   - OSeMBE v1.0|NOR
+  - OSeMBE v1.0|EU27 & EFTA


### PR DESCRIPTION
This PR changes the country names in the mapping of the upload natives for OSeMBE to full country names that originate from the pyam mapping.