### PR TITLE
Add entrypoint function for ECEMF scenario validation

### DIFF
--- a/workflow.py
+++ b/workflow.py
@@ -25,10 +25,12 @@ def main(df: pyam.IamDataFrame, dimensions=["region", "variable"]) -> pyam.IamDa
     logger.info("Starting openENTRANCE timeseries-upload processing workflow...")
 
     if "subannual" in df.dimensions or df.time_col == "time":
-        dimensions = dimensions + ["subannual"]
+        _dimensions = dimensions + ["subannual"]
+    else:
+        _dimensions = dimensions
 
     # import definitions and region-processor
-    definition = DataStructureDefinition(here / "definitions", dimensions=dimensions)
+    definition = DataStructureDefinition(here / "definitions", dimensions=_dimensions)
     processor = RegionProcessor.from_directory(path=here / "mappings")
 
     # check if directional data exists in the scenario data, add to region codelist

--- a/workflow.py
+++ b/workflow.py
@@ -45,7 +45,7 @@ def main(df: pyam.IamDataFrame, dimensions=["region", "variable"]) -> pyam.IamDa
                     definition.region[r] = None
 
     # validate the region and variable dimensions, apply region processing
-    df = process(df, definition, dimensions=["region", "variable"], processor=processor)
+    df = process(df, definition, dimensions=dimensions, processor=processor)
 
     # convert to subannual format if data provided in datetime format
     if df.time_col == "time":

--- a/workflow.py
+++ b/workflow.py
@@ -22,8 +22,6 @@ def ecemf(df: pyam.IamDataFrame) -> pyam.IamDataFrame:
 
 def main(df: pyam.IamDataFrame, dimensions=["region", "variable"]) -> pyam.IamDataFrame:
     """Main function for validation and processing"""
-    logger.info("Starting openENTRANCE timeseries-upload processing workflow...")
-
     if "subannual" in df.dimensions or df.time_col == "time":
         _dimensions = dimensions + ["subannual"]
     else:

--- a/workflow.py
+++ b/workflow.py
@@ -23,12 +23,14 @@ def ecemf(df: pyam.IamDataFrame) -> pyam.IamDataFrame:
 def main(df: pyam.IamDataFrame, dimensions=["region", "variable"]) -> pyam.IamDataFrame:
     """Main function for validation and processing"""
     if "subannual" in df.dimensions or df.time_col == "time":
-        _dimensions = dimensions + ["subannual"]
+        dsd_dimensions = dimensions + ["subannual"]
     else:
-        _dimensions = dimensions
+        dsd_dimensions = dimensions
 
     # import definitions and region-processor
-    definition = DataStructureDefinition(here / "definitions", dimensions=_dimensions)
+    definition = DataStructureDefinition(
+        here / "definitions", dimensions=dsd_dimensions
+    )
     processor = RegionProcessor.from_directory(path=here / "mappings")
 
     # check if directional data exists in the scenario data, add to region codelist

--- a/workflow.py
+++ b/workflow.py
@@ -15,14 +15,17 @@ EXP_TIME_OFFSET = timedelta(seconds=3600)
 OE_SUBANNUAL_FORMAT = lambda x: x.strftime("%m-%d %H:%M%z").replace("+0100", "+01:00")
 
 
-def main(df: pyam.IamDataFrame) -> pyam.IamDataFrame:
+def ecemf(df: pyam.IamDataFrame) -> pyam.IamDataFrame:
+    """Entrypoint for ECEMF scenario validation"""
+    return main(df, dimensions=["scenario", "region", "variable"])
+
+
+def main(df: pyam.IamDataFrame, dimensions=["region", "variable"]) -> pyam.IamDataFrame:
     """Main function for validation and processing"""
     logger.info("Starting openENTRANCE timeseries-upload processing workflow...")
 
     if "subannual" in df.dimensions or df.time_col == "time":
-        dimensions = ["region", "variable", "subannual"]
-    else:
-        dimensions = ["region", "variable"]
+        dimensions = dimensions + ["subannual"]
 
     # import definitions and region-processor
     definition = DataStructureDefinition(here / "definitions", dimensions=dimensions)


### PR DESCRIPTION
This PR adds a new top-level "entrypoint" function to perform scenario validation including checking the scenario names against a whitelist of allowed names from the folder `definitions/scenario`.

@phackstock, could you take a look?