### PR TITLE
Add Energy Storage System Type to possible electricity capacities

### DIFF
--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -4,6 +4,9 @@
 - Capacity|Electricity|{Electricity Input}:
     description: Total installed electricity generation capacity from {Electricity Input}
     unit: GW
+- Capacity|Electricity|{Energy Storage System Type}:
+    description: Total installed electricity generation capacity from {Energy Storage System Type}
+    unit: GW
 - Capacity|Heat|Residential and Commercial:
     description: Total installed heat generation capacity for the residential and
       commercial sectors

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -5,7 +5,7 @@
     description: Total installed electricity generation capacity from {Electricity Input}
     unit: GW
 - Capacity|Electricity|Energy Storage System:
-    description: Total installed electricity generation capacity from all {Energy Storage System Type} storage systems
+    description: Total installed electricity generation capacity from all storage systems
     unit: GW
 - Capacity|Electricity|Energy Storage System|{Energy Storage System Type}:
     description: Total installed electricity generation capacity from {Energy Storage System Type}

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -4,7 +4,10 @@
 - Capacity|Electricity|{Electricity Input}:
     description: Total installed electricity generation capacity from {Electricity Input}
     unit: GW
-- Capacity|Electricity|{Energy Storage System Type}:
+- Capacity|Electricity|Energy Storage System:
+    description: Total installed electricity generation capacity from all {Energy Storage System Type} storage systems
+    unit: GW
+- Capacity|Electricity|Energy Storage System|{Energy Storage System Type}:
     description: Total installed electricity generation capacity from {Energy Storage System Type}
     unit: GW
 - Capacity|Heat|Residential and Commercial:


### PR DESCRIPTION
This introduces the option to give installed capacities for storages, as requested in the openENTRANCE case studies.
This is different from the Maximum Storage (capacity vs energy content).