### PR TITLE
Pin to latest release of `nomenclature-iamc`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyam-iamc>=1.0  # the pyam package is released on pypi under this name
 iam-units>=2021.11.12
-git+https://github.com/IAMconsortium/nomenclature.git
+nomenclature-iamc


### PR DESCRIPTION
This is to deactivate over-zealous checking of weight-variables.