### PR TITLE
Add extra models from the remind group

### DIFF
--- a/mappings/remind_2.1.yaml
+++ b/mappings/remind_2.1.yaml
@@ -1,4 +1,9 @@
-model: REMIND 2.1
+model: 
+  - REMIND 2.1
+  - REMIND 3.0.0
+  - REMIND-Industry 3.0.0
+  - REMIND-Buildings 3.0.0
+  - EDGE-T 0.15.0
 native_regions:
   - CAZ: REMIND 2.1|CAZ
   - CHA: REMIND 2.1|CHA


### PR DESCRIPTION

This PR intends to add support for additional models from the REMIND group that share the same the same region definition.

**Question:** @danielhuppmann @phackstock 
How to proceed with the native regions definition?
Right now we expressly write the `REMIND 2.1` string in the native regions definition so we keep the uploaded data saved under the model name. However, as all models included in this pull request share the same regional definition, it would be much better if the model name part of the tag `REMIND 2.1|<region name>` would be created automatically by the db code, instead of creating multiple almost identical region mapping files, except for the replaced model name tag in the file.
Is this feature possible to be implemented? 

**Suggestion:**
Instead of using 
```
  - CAZ: REMIND 2.1|CAZ
```
support a key word like for example:
```
  - CAZ: <model>|CAZ
```
that would be filled automatically at the data processing time with the model name.

Please let me know if this would be possible or if I would need to go with the multiple files solution, with repeated regions definitions.