### PR TITLE
Add region and mapping for REMIND 3.0

### DIFF
--- a/definitions/region/model_native_regions/remind_3.0.yaml
+++ b/definitions/region/model_native_regions/remind_3.0.yaml
@@ -1,0 +1,24 @@
+# The model documentation for version 3.0.3 can be found at https://rse.pik-potsdam.de/doc/remind/3.0.3
+# REMIND 21 regions mapping can be found at https://git.io/JySgR and https://doi.org/10.1016/j.energy.2021.121908
+- REMIND 3.0:
+  - REMIND 3.0|CAZ
+  - REMIND 3.0|CHA
+  - REMIND 3.0|DEU
+  - REMIND 3.0|ECE
+  - REMIND 3.0|ECS
+  - REMIND 3.0|ENC
+  - REMIND 3.0|ESC
+  - REMIND 3.0|ESW
+  - REMIND 3.0|EWN
+  - REMIND 3.0|FRA
+  - REMIND 3.0|IND
+  - REMIND 3.0|JPN
+  - REMIND 3.0|LAM
+  - REMIND 3.0|MEA
+  - REMIND 3.0|NEN
+  - REMIND 3.0|NES
+  - REMIND 3.0|OAS
+  - REMIND 3.0|REF
+  - REMIND 3.0|SSA
+  - REMIND 3.0|UKI
+  - REMIND 3.0|USA

--- a/mappings/remind_3.0.yaml
+++ b/mappings/remind_3.0.yaml
@@ -1,0 +1,61 @@
+model:
+  - REMIND 3.0.0
+  - REMIND-Buildings 3.0.0
+  - REMIND-Industry 3.0.0
+  - EDGE-T 0.15.0
+native_regions:
+  - CAZ: REMIND 3.0|CAZ
+  - CHA: REMIND 3.0|CHA
+  - DEU: REMIND 3.0|DEU
+  - ECE: REMIND 3.0|ECE
+  - ECS: REMIND 3.0|ECS
+  - ENC: REMIND 3.0|ENC
+  - ESC: REMIND 3.0|ESC
+  - ESW: REMIND 3.0|ESW
+  - EWN: REMIND 3.0|EWN
+  - FRA: REMIND 3.0|FRA
+  - IND: REMIND 3.0|IND
+  - JPN: REMIND 3.0|JPN
+  - LAM: REMIND 3.0|LAM
+  - MEA: REMIND 3.0|MEA
+  - NEN: REMIND 3.0|NEN
+  - NES: REMIND 3.0|NES
+  - OAS: REMIND 3.0|OAS
+  - REF: REMIND 3.0|REF
+  - SSA: REMIND 3.0|SSA
+  - UKI: REMIND 3.0|UKI
+  - USA: REMIND 3.0|USA
+  - EUR: EU27 & UK
+  - EU27
+  - World
+common_regions:
+  - Germany:
+      - DEU
+  - France:
+      - FRA
+  - Asia (R5):
+      - CHA
+      - IND
+      - OAS
+  - Latin America (R5):
+      - LAM
+  - Middle East & Africa (R5):
+      - SSA
+      - MEA
+  - OECD & EU (R5):
+      - DEU
+      - ECE
+      - ENC
+      - ECS
+      - ESC
+      - ESW
+      - EWN
+      - FRA
+      - UKI
+      - JPN
+      - USA
+      - CAZ
+      - NEN
+      - NES
+  - Reforming Economies (R5):
+      - REF


### PR DESCRIPTION
This PR implements the discussion from #208 about REMIND 3.0 regions as separate files keeping the existing model-mapping for REMIND 2.1 unchanged (to not alter behavior for existing model submissions to the IIASA database infrastructure).

We will also add guidance on region-naming conventions, see https://github.com/IAMconsortium/nomenclature/issues/142