### PR TITLE
Add pumped-hydro as storage option

### DIFF
--- a/definitions/variable/tag_electricity_input_types.yaml
+++ b/definitions/variable/tag_electricity_input_types.yaml
@@ -284,7 +284,10 @@
   - Hydro|Pumped Storage:
       description: hydropower systems with short-term storage capacity
         (including pumping turbines)
-      notes: This hydropower system has two water reservoirs at different elevations.
+      notes: This variable should only include electricity generation from natural
+        inflow of water into the upper reservoir. Electricity from storage operation
+        should be denoted by *"Injected Energy|.."* and *Discharded Energy|..*.
+        This hydropower system has two water reservoirs at different elevations.
         The definition follows the convention established
         by the ENTSO-E transparency platform (https://transparency.entsoe.eu).
   - Hydro|Reservoir:

--- a/definitions/variable/tag_electricity_input_types.yaml
+++ b/definitions/variable/tag_electricity_input_types.yaml
@@ -284,10 +284,7 @@
   - Hydro|Pumped Storage:
       description: hydropower systems with short-term storage capacity
         (including pumping turbines)
-      notes: This variable should only include electricity generation from natural
-        inflow of water into the upper reservoir. Electricity from storage operation
-        should be denoted by *"Injected Energy|.."* and *Discharded Energy|..*.
-        This hydropower system has two water reservoirs at different elevations.
+      notes: This hydropower system has two water reservoirs at different elevations.
         The definition follows the convention established
         by the ENTSO-E transparency platform (https://transparency.entsoe.eu).
   - Hydro|Reservoir:

--- a/definitions/variable/tag_electricity_storage_types.yaml
+++ b/definitions/variable/tag_electricity_storage_types.yaml
@@ -6,12 +6,12 @@
 - Electricity Storage Type:
 
   - Energy Storage System:
-      description: Mainly to refer to the batteries
+      description: all types of energy storage including pumped hydro and batteries
   - Energy Storage System|Pumped Hydro Storage:
       description: pumped-hydro storage
   - Energy Storage System|Lithium-Ion:
-      description: Lithium-Ion batteries
+      description: lithium-ion batteries
   - Energy Storage System|Redox Flow:
-      description: Redox Flow batteries
+      description: redox flow batteries
   - Energy Storage System|Compressed Air:
-      description: Compressed Air batteries
+      description: compressed air storage systems

--- a/definitions/variable/tag_electricity_storage_types.yaml
+++ b/definitions/variable/tag_electricity_storage_types.yaml
@@ -7,6 +7,8 @@
 
   - Energy Storage System:
       description: Mainly to refer to the batteries
+  - Energy Storage System|Pumped Hydro Storage:
+      description: pumped-hydro storage
   - Energy Storage System|Lithium-Ion:
       description: Lithium-Ion batteries
   - Energy Storage System|Redox Flow:

--- a/definitions/variable/tag_electricity_storage_types.yaml
+++ b/definitions/variable/tag_electricity_storage_types.yaml
@@ -23,8 +23,6 @@
         (possibly including pumping turbines)
       notes: This definition follows the convention established
         by the ENTSO-E transparency platform (https://transparency.entsoe.eu).
-  - Energy Storage System|Pumped Hydro Storage:
-      description: pumped-hydro storage
   - Energy Storage System|Lithium-Ion:
       description: lithium-ion batteries
   - Energy Storage System|Redox Flow:

--- a/definitions/variable/tag_electricity_storage_types.yaml
+++ b/definitions/variable/tag_electricity_storage_types.yaml
@@ -7,6 +7,22 @@
 
   - Energy Storage System:
       description: all types of energy storage including pumped hydro and batteries
+  - Energy Storage System|Hydro:
+      description: all hydropower storage systems
+  - Energy Storage System|Hydro|Pumped Storage:
+      description: hydropower systems with short-term storage capacity
+        (including pumping turbines)
+      notes: This variable should only include electricity generation from natural
+        inflow of water into the upper reservoir. Electricity from storage operation
+        should be denoted by *"Injected Energy|.."* and *Discharded Energy|..*.
+        This hydropower system has two water reservoirs at different elevations.
+        The definition follows the convention established
+        by the ENTSO-E transparency platform (https://transparency.entsoe.eu).
+  - Energy Storage System|Hydro|Reservoir:
+      description: hydropower systems with seasonal storage capacity
+        (possibly including pumping turbines)
+      notes: This definition follows the convention established
+        by the ENTSO-E transparency platform (https://transparency.entsoe.eu).
   - Energy Storage System|Pumped Hydro Storage:
       description: pumped-hydro storage
   - Energy Storage System|Lithium-Ion:


### PR DESCRIPTION
This PR follows on #196, related to #199.

The PR clarifies the distinction between "new" electricity generation at pumped-hydro power plants (from natural water inflow) versus the injection/discharge at these plants (as storage operation).

An alternative would be to include all "new" electricity generation  as "Hydro|Reservoir".