### PR TITLE
Add region-aggregation-mapping for `FORECAST v1.0`

### DIFF
--- a/mappings/FORECAST_v1.0.yaml
+++ b/mappings/FORECAST_v1.0.yaml
@@ -1,0 +1,61 @@
+model:
+  - FORECAST v1.0
+native_regions:
+  - Austria
+  - Belgium
+  - Bulgaria
+  - Croatia
+  - Cyprus
+  - Czech Republic
+  - Denmark
+  - Estonia
+  - Finland
+  - France
+  - Germany
+  - Greece
+  - Hungary
+  - Ireland
+  - Italy
+  - Latvia
+  - Lithuania
+  - Luxembourg
+  - Malta
+  - The Netherlands
+  - Poland
+  - Portugal
+  - Romania
+  - Slovakia
+  - Slovenia
+  - Spain
+  - Sweden
+  - United Kingdom
+common_regions:
+  - EU27 & UK:
+      - Austria
+      - Belgium
+      - Bulgaria
+      - Croatia
+      - Cyprus
+      - Czech Republic
+      - Denmark
+      - Estonia
+      - Finland
+      - France
+      - Germany
+      - Greece
+      - Hungary
+      - Ireland
+      - Italy
+      - Latvia
+      - Lithuania
+      - Luxembourg
+      - Malta
+      - The Netherlands
+      - Poland
+      - Portugal
+      - Romania
+      - Slovakia
+      - Slovenia
+      - Spain
+      - Sweden
+      - United Kingdom


### PR DESCRIPTION
This PR adds the region-aggregation mapping for the "FORECAST v1.0" model.

Because this model has a national resolution, the region=country-names are uploaded as is and are not renamed to a structure `<Model>|<Region>`.

fyi @MatthiasRehfeldt 