### PR TITLE
Re-insert additional prices at the secondary-energy level

### DIFF
--- a/definitions/variable/energy/energy-prices.yaml
+++ b/definitions/variable/energy/energy-prices.yaml
@@ -69,12 +69,12 @@
     unit: [EUR_2020/GJ, USD_2010/GJ]
     weight: Secondary Energy|Gases
 
-- Price|Secondary Energy|Gases|Natural Gas:
+- Price|Secondary Energy|Gases|Fossil:
     description: Natural gas price at the secondary level, i.e. for large-scale
       consumers (e.g., gas power plant)
     notes: Prices should include the effect of carbon prices.
     unit: [EUR_2020/GJ, USD_2010/GJ]
-    weight: Secondary Energy|Gases|Natural Gas
+    weight: Secondary Energy|Gases|Fossil
 
 - Price|Secondary Energy|Gases|Biomass:
     description: Biogas price at the secondary level, i.e. for large-scale consumers
@@ -108,6 +108,11 @@
     notes: Prices should include the effect of carbon prices.
     unit: [EUR_2020/GJ, USD_2010/GJ]
     weight: Secondary Energy|Solids|Biomass
+
+- Price|Secondary Energy|Solids|Biomass|Traditional:
+    description: Price for traditional biomass at the secondary level
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Solids|Biomass|Traditional
 
 - Price|Secondary Energy|Hydrogen:
     description: Hydrogen price at the secondary level, i.e. for large-scale consumers

--- a/definitions/variable/energy/energy-prices.yaml
+++ b/definitions/variable/energy/energy-prices.yaml
@@ -62,6 +62,13 @@
     unit: [EUR_2020/GJ, USD_2010/GJ]
     weight: Secondary Energy|Electricity
 
+- Price|Secondary Energy|Gases:
+    description: Price for gaseous fuels at the secondary level, i.e. for large-scale
+      consumers (e.g., gas power plant)
+    notes: Prices should include the effect of carbon prices.
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Gases
+
 - Price|Secondary Energy|Gases|Natural Gas:
     description: Natural gas price at the secondary level, i.e. for large-scale
       consumers (e.g., gas power plant)
@@ -69,7 +76,27 @@
     unit: [EUR_2020/GJ, USD_2010/GJ]
     weight: Secondary Energy|Gases|Natural Gas
 
-- Price|Secondary Energy|Solids|Coal:
+- Price|Secondary Energy|Gases|Biomass:
+    description: Biogas price at the secondary level, i.e. for large-scale consumers
+    notes: Prices should include the effect of carbon prices.
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Gases|Biomass
+
+- Price|Secondary Energy|Gases|Electricity:
+    description: Price for synthetic gas at the secondary level,
+      i.e. for large-scale consumers
+    notes: Prices should include the effect of carbon prices.
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Gases|Biomass
+
+- Price|Secondary Energy|Solids:
+    description: Price for solid fuels at the secondary level, i.e. for large-scale consumers
+      (e.g. coal power plant)
+    notes: Prices should include the effect of carbon prices.
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Solids
+
+- Price|Secondary Energy|Solids|Fossil:
     description: Coal price at the secondary level, i.e. for large-scale consumers
       (e.g. coal power plant)
     notes: Prices should include the effect of carbon prices.
@@ -88,14 +115,54 @@
     unit: [EUR_2020/GJ, USD_2010/GJ]
     weight: Secondary Energy|Hydrogen
 
+- Price|Secondary Energy|Hydrogen|Biomass:
+    description: Price for hydrogen from biomass at the secondary level, i.e. for
+      large-scale consumers
+    notes: Prices should include the effect of carbon prices.
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Hydrogen|Biomass
+
+- Price|Secondary Energy|Hydrogen|Electricity:
+    description: Price for synthetic hydrogen at the secondary level, i.e. for
+      large-scale consumers
+    notes: Prices should include the effect of carbon prices.
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Hydrogen|Electricity
+
+- Price|Secondary Energy|Hydrogen|Fossil:
+    description: Price for hydrogen from natural gas ("grey hydrogen") at the secondary
+      level, i.e. for large-scale consumers
+    notes: Prices should include the effect of carbon prices.
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Hydrogen|Fossil
+
+- Price|Secondary Energy|Liquids:
+    description: Price for liquid fuels at the secondary level, i.e. for large-scale
+      consumers
+    notes: Prices should include the effect of carbon prices.
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Liquids
+
 - Price|Secondary Energy|Liquids|Biomass:
     description: Biofuels price at the secondary level, i.e. for large-scale consumers
     notes: Prices should include the effect of carbon prices.
     unit: [EUR_2020/GJ, USD_2010/GJ]
     weight: Secondary Energy|Liquids|Biomass
 
-- Price|Secondary Energy|Liquids|Oil:
+- Price|Secondary Energy|Liquids|Electricity:
+    description: Price for e-fuels at the secondary level, i.e. for large-scale consumers
+    notes: Prices should include the effect of carbon prices.
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Liquids|Biomass
+
+- Price|Secondary Energy|Liquids|Fossil:
     description: Price for oil products at the secondary level, i.e. for large-scale consumers
     notes: Prices should include the effect of carbon prices.
     unit: [EUR_2020/GJ, USD_2010/GJ]
     weight: Secondary Energy|Liquids|Oil
+
+- Price|Secondary Energy|Heat:
+    description: Price for heat at the secondary level, i.e. for large-scale consumers
+    notes: Prices should include the effect of carbon prices.
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Heat

--- a/definitions/variable/energy/energy-prices.yaml
+++ b/definitions/variable/energy/energy-prices.yaml
@@ -69,16 +69,33 @@
     unit: [EUR_2020/GJ, USD_2010/GJ]
     weight: Secondary Energy|Gases|Natural Gas
 
-- Price|Secondary Energy|Liquids|Oil:
-    description: Light fuel oil price at the secondary level, i.e. for large-scale
-      consumers (e.g. oil power plant)
-    notes: Prices should include the effect of carbon prices.
-    unit: [EUR_2020/GJ, USD_2010/GJ]
-    weight: Secondary Energy|Liquids|Oil
-
 - Price|Secondary Energy|Solids|Coal:
     description: Coal price at the secondary level, i.e. for large-scale consumers
       (e.g. coal power plant)
     notes: Prices should include the effect of carbon prices.
     unit: [EUR_2020/GJ, USD_2010/GJ]
     weight: Secondary Energy|Solids|Coal
+
+- Price|Secondary Energy|Solids|Biomass:
+    description: Biomass price at the secondary level, i.e. for large-scale consumers
+    notes: Prices should include the effect of carbon prices.
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Solids|Biomass
+
+- Price|Secondary Energy|Hydrogen:
+    description: Hydrogen price at the secondary level, i.e. for large-scale consumers
+    notes: Prices should include the effect of carbon prices.
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Hydrogen
+
+- Price|Secondary Energy|Liquids|Biomass:
+    description: Biofuels price at the secondary level, i.e. for large-scale consumers
+    notes: Prices should include the effect of carbon prices.
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Liquids|Biomass
+
+- Price|Secondary Energy|Liquids|Oil:
+    description: Price for oil products at the secondary level, i.e. for large-scale consumers
+    notes: Prices should include the effect of carbon prices.
+    unit: [EUR_2020/GJ, USD_2010/GJ]
+    weight: Secondary Energy|Liquids|Oil

--- a/definitions/variable/energy/energy-secondary.yaml
+++ b/definitions/variable/energy/energy-secondary.yaml
@@ -43,9 +43,6 @@
 - Secondary Energy|Gases|Coal:
     description: Total production of coal gas from coal gasification
     unit: EJ/yr
-- Secondary Energy|Gases|Gas:
-    description: Total production of fossil natural gas
-    unit: EJ/yr
 - Secondary Energy|Gases|Natural Gas:
     description: Total production of fossil natural gas
     unit: EJ/yr

--- a/definitions/variable/energy/energy-secondary.yaml
+++ b/definitions/variable/energy/energy-secondary.yaml
@@ -43,7 +43,7 @@
 - Secondary Energy|Gases|Coal:
     description: Total production of coal gas from coal gasification
     unit: EJ/yr
-- Secondary Energy|Gases|Natural Gas:
+- Secondary Energy|Gases|Gas:
     description: Total production of fossil natural gas
     unit: EJ/yr
 - Secondary Energy|Heat:


### PR DESCRIPTION
This PR adds variables for prices at the secondary energy level. The variables match those used in the ENGAGE project.

closes  #221