### PR TITLE
Change name to area_name

### DIFF
--- a/definitions/region/nuts1.yaml
+++ b/definitions/region/nuts1.yaml
@@ -4,488 +4,488 @@
 # List of NUTS1 regions: major socio-economic regions
 - NUTS1:
   - BE1:
-      name: Région de Bruxelles-Capitale/Brussels Hoofdstedelijk Gewest
+      area_name: Région de Bruxelles-Capitale/Brussels Hoofdstedelijk Gewest
       country: Belgium
   - BE2:
-      name: Vlaams Gewest
+      area_name: Vlaams Gewest
       country: Belgium
   - BE3:
-      name: Région wallonne
+      area_name: Région wallonne
       country: Belgium
   - BEZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Belgium
   - BG3:
-      name: Северна и югоизточна България
+      area_name: Северна и югоизточна България
       country: Bulgaria
   - BG4:
-      name: Югозападна и южна централна България
+      area_name: Югозападна и южна централна България
       country: Bulgaria
   - BGZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Bulgaria
   - CZ0:
-      name: Česko
+      area_name: Česko
       country: Czech Republic
   - CZZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Czech Republic
   - DK0:
-      name: Danmark
+      area_name: Danmark
       country: Denmark
   - DKZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Denmark
   - DE1:
-      name: Baden-Württemberg
+      area_name: Baden-Württemberg
       country: Germany
   - DE2:
-      name: Bayern
+      area_name: Bayern
       country: Germany
   - DE3:
-      name: Berlin
+      area_name: Berlin
       country: Germany
   - DE4:
-      name: Brandenburg
+      area_name: Brandenburg
       country: Germany
   - DE5:
-      name: Bremen
+      area_name: Bremen
       country: Germany
   - DE6:
-      name: Hamburg
+      area_name: Hamburg
       country: Germany
   - DE7:
-      name: Hessen
+      area_name: Hessen
       country: Germany
   - DE8:
-      name: Mecklenburg-Vorpommern
+      area_name: Mecklenburg-Vorpommern
       country: Germany
   - DE9:
-      name: Niedersachsen
+      area_name: Niedersachsen
       country: Germany
   - DEA:
-      name: Nordrhein-Westfalen
+      area_name: Nordrhein-Westfalen
       country: Germany
   - DEB:
-      name: Rheinland-Pfalz
+      area_name: Rheinland-Pfalz
       country: Germany
   - DEC:
-      name: Saarland
+      area_name: Saarland
       country: Germany
   - DED:
-      name: Sachsen
+      area_name: Sachsen
       country: Germany
   - DEE:
-      name: Sachsen-Anhalt
+      area_name: Sachsen-Anhalt
       country: Germany
   - DEF:
-      name: Schleswig-Holstein
+      area_name: Schleswig-Holstein
       country: Germany
   - DEG:
-      name: Thüringen
+      area_name: Thüringen
       country: Germany
   - DEZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Germany
   - EE0:
-      name: Eesti
+      area_name: Eesti
       country: Estonia
   - EEZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Estonia
   - IE0:
-      name: Ireland
+      area_name: Ireland
       country: Ireland
   - IEZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Ireland
   - EL3:
-      name: Αττική 
+      area_name: Αττική 
       country: Greece
   - EL4:
-      name: Νησιά Αιγαίου, Κρήτη
+      area_name: Νησιά Αιγαίου, Κρήτη
       country: Greece
   - EL5:
-      name: Βόρεια Ελλάδα
+      area_name: Βόρεια Ελλάδα
       country: Greece
   - EL6:
-      name: Κεντρική Ελλάδα
+      area_name: Κεντρική Ελλάδα
       country: Greece
   - ELZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Greece
   - ES1:
-      name: Noroeste
+      area_name: Noroeste
       country: Spain
   - ES2:
-      name: Noreste
+      area_name: Noreste
       country: Spain
   - ES3:
-      name: Comunidad de Madrid
+      area_name: Comunidad de Madrid
       country: Spain
   - ES4:
-      name: Centro (ES)
+      area_name: Centro (ES)
       country: Spain
   - ES5:
-      name: Este
+      area_name: Este
       country: Spain
   - ES6:
-      name: Sur
+      area_name: Sur
       country: Spain
   - ES7:
-      name: Canarias
+      area_name: Canarias
       country: Spain
   - ESZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Spain
   - FR1:
-      name: Ile-de-France
+      area_name: Ile-de-France
       country: France
   - FRB:
-      name: Centre — Val de Loire
+      area_name: Centre — Val de Loire
       country: France
   - FRC:
-      name: Bourgogne-Franche-Comté
+      area_name: Bourgogne-Franche-Comté
       country: France
   - FRD:
-      name: Normandie
+      area_name: Normandie
       country: France
   - FRE:
-      name: Hauts-de-France
+      area_name: Hauts-de-France
       country: France
   - FRF:
-      name: Grand Est
+      area_name: Grand Est
       country: France
   - FRG:
-      name: Pays de la Loire
+      area_name: Pays de la Loire
       country: France
   - FRH:
-      name: Bretagne
+      area_name: Bretagne
       country: France
   - FRI:
-      name: Nouvelle-Aquitaine
+      area_name: Nouvelle-Aquitaine
       country: France
   - FRJ:
-      name: Occitanie
+      area_name: Occitanie
       country: France
   - FRK:
-      name: Auvergne-Rhône-Alpes
+      area_name: Auvergne-Rhône-Alpes
       country: France
   - FRL:
-      name: Provence-Alpes-Côte d’Azur
+      area_name: Provence-Alpes-Côte d’Azur
       country: France
   - FRM:
-      name: Corse
+      area_name: Corse
       country: France
   - FRY:
-      name: RUP FR — Régions Ultrapériphériques Françaises
+      area_name: RUP FR — Régions Ultrapériphériques Françaises
       country: France
   - FRZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: France
   - HR0:
-      name: Hrvatska
+      area_name: Hrvatska
       country: Croatia
   - HRZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Croatia
   - ITC:
-      name: Nord-Ovest
+      area_name: Nord-Ovest
       country: Italy
   - ITF:
-      name: Sud
+      area_name: Sud
       country: Italy
   - ITG:
-      name: Isole
+      area_name: Isole
       country: Italy
   - ITH:
-      name: Nord-Est
+      area_name: Nord-Est
       country: Italy
   - ITI:
-      name: Centro (IT)
+      area_name: Centro (IT)
       country: Italy
   - ITZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Italy
   - CY0:
-      name: Κύπρος
+      area_name: Κύπρος
       country: Cyprus
   - CYZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Cyprus
   - LV0:
-      name: Latvija
+      area_name: Latvija
       country: Latvia
   - LVZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Latvia
   - LT0:
-      name: Lietuva
+      area_name: Lietuva
       country: Lithuania
   - LTZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Lithuania
   - LU0:
-      name: Luxembourg
+      area_name: Luxembourg
       country: Luxembourg
   - LUZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Luxembourg
   - HU1:
-      name: Közép-Magyarország
+      area_name: Közép-Magyarország
       country: Hungary
   - HU2:
-      name: Dunántúl
+      area_name: Dunántúl
       country: Hungary
   - HU3:
-      name: Alföld és Észak
+      area_name: Alföld és Észak
       country: Hungary
   - HUZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Hungary
   - MT0:
-      name: Malta
+      area_name: Malta
       country: Malta
   - MTZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Malta
   - NL1:
-      name: Noord-Nederland
+      area_name: Noord-Nederland
       country: The Netherlands
   - NL2:
-      name: Oost-Nederland
+      area_name: Oost-Nederland
       country: The Netherlands
   - NL3:
-      name: West-Nederland
+      area_name: West-Nederland
       country: The Netherlands
   - NL4:
-      name: Zuid-Nederland
+      area_name: Zuid-Nederland
       country: The Netherlands
   - NLZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: The Netherlands
   - AT1:
-      name: Ostösterreich
+      area_name: Ostösterreich
       country: Austria
   - AT2:
-      name: Südösterreich
+      area_name: Südösterreich
       country: Austria
   - AT3:
-      name: Westösterreich
+      area_name: Westösterreich
       country: Austria
   - ATZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Austria
   - PL2:
-      name: Makroregion południowy
+      area_name: Makroregion południowy
       country: Poland
   - PL4:
-      name: Makroregion północno-zachodni
+      area_name: Makroregion północno-zachodni
       country: Poland
   - PL5:
-      name: Makroregion południowo-zachodni
+      area_name: Makroregion południowo-zachodni
       country: Poland
   - PL6:
-      name: Makroregion północny
+      area_name: Makroregion północny
       country: Poland
   - PL7:
-      name: Makroregion centralny
+      area_name: Makroregion centralny
       country: Poland
   - PL8:
-      name: Makroregion wschodni
+      area_name: Makroregion wschodni
       country: Poland
   - PL9:
-      name: Makroregion województwo mazowieckie
+      area_name: Makroregion województwo mazowieckie
       country: Poland
   - PLZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Poland
   - PT1:
-      name: Continente
+      area_name: Continente
       country: Portugal
   - PT2:
-      name: Região Autónoma dos Açores
+      area_name: Região Autónoma dos Açores
       country: Portugal
   - PT3:
-      name: Região Autónoma da Madeira
+      area_name: Região Autónoma da Madeira
       country: Portugal
   - PTZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Portugal
   - RO1:
-      name: Macroregiunea Unu
+      area_name: Macroregiunea Unu
       country: Romania
   - RO2:
-      name: Macroregiunea Doi
+      area_name: Macroregiunea Doi
       country: Romania
   - RO3:
-      name: Macroregiunea Trei
+      area_name: Macroregiunea Trei
       country: Romania
   - RO4:
-      name: Macroregiunea Patru
+      area_name: Macroregiunea Patru
       country: Romania
   - ROZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Romania
   - SI0:
-      name: Slovenija
+      area_name: Slovenija
       country: Slovenia
   - SIZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Slovenia
   - SK0:
-      name: Slovensko
+      area_name: Slovensko
       country: Slovakia
   - SKZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Slovakia
   - FI1:
-      name: Manner-Suomi
+      area_name: Manner-Suomi
       country: Finland
   - FI2:
-      name: Åland
+      area_name: Åland
       country: Finland
   - FIZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Finland
   - SE1:
-      name: Östra Sverige
+      area_name: Östra Sverige
       country: Sweden
   - SE2:
-      name: Södra Sverige
+      area_name: Södra Sverige
       country: Sweden
   - SE3:
-      name: Norra Sverige
+      area_name: Norra Sverige
       country: Sweden
   - SEZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Sweden
   - UKC:
-      name: North East (England)
+      area_name: North East (England)
       country: United Kingdom
   - UKD:
-      name: North West (England)
+      area_name: North West (England)
       country: United Kingdom
   - UKE:
-      name: Yorkshire and the Humber
+      area_name: Yorkshire and the Humber
       country: United Kingdom
   - UKF:
-      name: East Midlands (England)
+      area_name: East Midlands (England)
       country: United Kingdom
   - UKG:
-      name: West Midlands (England)
+      area_name: West Midlands (England)
       country: United Kingdom
   - UKH:
-      name: East of England
+      area_name: East of England
       country: United Kingdom
   - UKI:
-      name: London
+      area_name: London
       country: United Kingdom
   - UKJ:
-      name: South East (England)
+      area_name: South East (England)
       country: United Kingdom
   - UKK:
-      name: South West (England)
+      area_name: South West (England)
       country: United Kingdom
   - UKL:
-      name: Wales
+      area_name: Wales
       country: United Kingdom
   - UKM:
-      name: Scotland
+      area_name: Scotland
       country: United Kingdom
   - UKN:
-      name: Northern Ireland
+      area_name: Northern Ireland
       country: United Kingdom
   - UKZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: United Kingdom
   - IS0:
-      name: Ísland
+      area_name: Ísland
       country: Iceland
   - ISZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Iceland
   - LI0:
-      name: Liechtenstein
+      area_name: Liechtenstein
       country: Liechtenstein
   - LIZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Liechtenstein
   - NO0:
-      name: Norge
+      area_name: Norge
       country: Norway
   - NOZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Norway
   - CH0:
-      name: Schweiz/Suisse/Svizzera
+      area_name: Schweiz/Suisse/Svizzera
       country: Switzerland
   - CHZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Switzerland
   - ME0:
-      name: Црна Гора 
+      area_name: Црна Гора 
       country: Montenegro
   - MEZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Montenegro
   - MK0:
-      name: Северна Македонија
+      area_name: Северна Македонија
       country: North Macedonia
   - MKZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: North Macedonia
   - AL0:
-      name: Shqipëria
+      area_name: Shqipëria
       country: Albania
   - ALZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Albania
   - RS1:
-      name: Србија - север 
+      area_name: Србија - север 
       country: Serbia
   - RS2:
-      name: Србија - југ 
+      area_name: Србија - југ 
       country: Serbia
   - RSZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Serbia
   - TR1:
-      name: İstanbul
+      area_name: İstanbul
       country: Turkey
   - TR2:
-      name: Batı Marmara
+      area_name: Batı Marmara
       country: Turkey
   - TR3:
-      name: Ege
+      area_name: Ege
       country: Turkey
   - TR4:
-      name: Doğu Marmara
+      area_name: Doğu Marmara
       country: Turkey
   - TR5:
-      name: Batı Anadolu
+      area_name: Batı Anadolu
       country: Turkey
   - TR6:
-      name: Akdeniz
+      area_name: Akdeniz
       country: Turkey
   - TR7:
-      name: Orta Anadolu
+      area_name: Orta Anadolu
       country: Turkey
   - TR8:
-      name: Batı Karadeniz
+      area_name: Batı Karadeniz
       country: Turkey
   - TR9:
-      name: Doğu Karadeniz
+      area_name: Doğu Karadeniz
       country: Turkey
   - TRA:
-      name: Kuzeydoğu Anadolu
+      area_name: Kuzeydoğu Anadolu
       country: Turkey
   - TRB:
-      name: Ortadoğu Anadolu
+      area_name: Ortadoğu Anadolu
       country: Turkey
   - TRC:
-      name: Güneydoğu Anadolu
+      area_name: Güneydoğu Anadolu
       country: Turkey
   - TRZ:
-      name: Extra-Regio NUTS 1
+      area_name: Extra-Regio NUTS 1
       country: Turkey

--- a/definitions/region/nuts2.yaml
+++ b/definitions/region/nuts2.yaml
@@ -4,1486 +4,1486 @@
 # List of NUTS2 regions: basic regions for the application of regional policies
 - NUTS2:
   - BE10:
-      name: Région de Bruxelles-Capitale/ Brussels Hoofdstedelijk Gewest
+      area_name: Région de Bruxelles-Capitale/ Brussels Hoofdstedelijk Gewest
       country: Belgium
       nuts1: BE1
   - BE21:
-      name: Prov. Antwerpen
+      area_name: Prov. Antwerpen
       country: Belgium
       nuts1: BE2
   - BE22:
-      name: Prov. Limburg (BE)
+      area_name: Prov. Limburg (BE)
       country: Belgium
       nuts1: BE2
   - BE23:
-      name: Prov. Oost-Vlaanderen
+      area_name: Prov. Oost-Vlaanderen
       country: Belgium
       nuts1: BE2
   - BE24:
-      name: Prov. Vlaams-Brabant
+      area_name: Prov. Vlaams-Brabant
       country: Belgium
       nuts1: BE2
   - BE25:
-      name: Prov. West-Vlaanderen
+      area_name: Prov. West-Vlaanderen
       country: Belgium
       nuts1: BE2
   - BE31:
-      name: Prov. Brabant Wallon
+      area_name: Prov. Brabant Wallon
       country: Belgium
       nuts1: BE3
   - BE32:
-      name: Prov. Hainaut
+      area_name: Prov. Hainaut
       country: Belgium
       nuts1: BE3
   - BE33:
-      name: Prov. Liège
+      area_name: Prov. Liège
       country: Belgium
       nuts1: BE3
   - BE34:
-      name: Prov. Luxembourg (BE)
+      area_name: Prov. Luxembourg (BE)
       country: Belgium
       nuts1: BE3
   - BE35:
-      name: Prov. Namur
+      area_name: Prov. Namur
       country: Belgium
       nuts1: BE3
   - BEZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Belgium
       nuts1: BEZ
   - BG31:
-      name: Северозападен
+      area_name: Северозападен
       country: Bulgaria
       nuts1: BG3
   - BG32:
-      name: Северен централен
+      area_name: Северен централен
       country: Bulgaria
       nuts1: BG3
   - BG33:
-      name: Североизточен
+      area_name: Североизточен
       country: Bulgaria
       nuts1: BG3
   - BG34:
-      name: Югоизточен
+      area_name: Югоизточен
       country: Bulgaria
       nuts1: BG3
   - BG41:
-      name: Югозападен
+      area_name: Югозападен
       country: Bulgaria
       nuts1: BG4
   - BG42:
-      name: Южен централен
+      area_name: Южен централен
       country: Bulgaria
       nuts1: BG4
   - BGZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Bulgaria
       nuts1: BGZ
   - CZ01:
-      name: Praha
+      area_name: Praha
       country: Czech Republic
       nuts1: CZ0
   - CZ02:
-      name: Střední Čechy
+      area_name: Střední Čechy
       country: Czech Republic
       nuts1: CZ0
   - CZ03:
-      name: Jihozápad
+      area_name: Jihozápad
       country: Czech Republic
       nuts1: CZ0
   - CZ04:
-      name: Severozápad
+      area_name: Severozápad
       country: Czech Republic
       nuts1: CZ0
   - CZ05:
-      name: Severovýchod
+      area_name: Severovýchod
       country: Czech Republic
       nuts1: CZ0
   - CZ06:
-      name: Jihovýchod
+      area_name: Jihovýchod
       country: Czech Republic
       nuts1: CZ0
   - CZ07:
-      name: Střední Morava
+      area_name: Střední Morava
       country: Czech Republic
       nuts1: CZ0
   - CZ08:
-      name: Moravskoslezsko
+      area_name: Moravskoslezsko
       country: Czech Republic
       nuts1: CZ0
   - CZZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Czech Republic
       nuts1: CZZ
   - DK01:
-      name: Hovedstaden
+      area_name: Hovedstaden
       country: Denmark
       nuts1: DK0
   - DK02:
-      name: Sjælland
+      area_name: Sjælland
       country: Denmark
       nuts1: DK0
   - DK03:
-      name: Syddanmark
+      area_name: Syddanmark
       country: Denmark
       nuts1: DK0
   - DK04:
-      name: Midtjylland
+      area_name: Midtjylland
       country: Denmark
       nuts1: DK0
   - DK05:
-      name: Nordjylland
+      area_name: Nordjylland
       country: Denmark
       nuts1: DK0
   - DKZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Denmark
       nuts1: DKZ
   - DE11:
-      name: Stuttgart
+      area_name: Stuttgart
       country: Germany
       nuts1: DE1
   - DE12:
-      name: Karlsruhe
+      area_name: Karlsruhe
       country: Germany
       nuts1: DE1
   - DE13:
-      name: Freiburg
+      area_name: Freiburg
       country: Germany
       nuts1: DE1
   - DE14:
-      name: Tübingen
+      area_name: Tübingen
       country: Germany
       nuts1: DE1
   - DE21:
-      name: Oberbayern
+      area_name: Oberbayern
       country: Germany
       nuts1: DE2
   - DE22:
-      name: Niederbayern
+      area_name: Niederbayern
       country: Germany
       nuts1: DE2
   - DE23:
-      name: Oberpfalz
+      area_name: Oberpfalz
       country: Germany
       nuts1: DE2
   - DE24:
-      name: Oberfranken
+      area_name: Oberfranken
       country: Germany
       nuts1: DE2
   - DE25:
-      name: Mittelfranken
+      area_name: Mittelfranken
       country: Germany
       nuts1: DE2
   - DE26:
-      name: Unterfranken
+      area_name: Unterfranken
       country: Germany
       nuts1: DE2
   - DE27:
-      name: Schwaben
+      area_name: Schwaben
       country: Germany
       nuts1: DE2
   - DE30:
-      name: Berlin
+      area_name: Berlin
       country: Germany
       nuts1: DE3
   - DE40:
-      name: Brandenburg
+      area_name: Brandenburg
       country: Germany
       nuts1: DE4
   - DE50:
-      name: Bremen
+      area_name: Bremen
       country: Germany
       nuts1: DE5
   - DE60:
-      name: Hamburg
+      area_name: Hamburg
       country: Germany
       nuts1: DE6
   - DE71:
-      name: Darmstadt
+      area_name: Darmstadt
       country: Germany
       nuts1: DE7
   - DE72:
-      name: Gießen
+      area_name: Gießen
       country: Germany
       nuts1: DE7
   - DE73:
-      name: Kassel
+      area_name: Kassel
       country: Germany
       nuts1: DE7
   - DE80:
-      name: Mecklenburg-Vorpommern
+      area_name: Mecklenburg-Vorpommern
       country: Germany
       nuts1: DE8
   - DE91:
-      name: Braunschweig
+      area_name: Braunschweig
       country: Germany
       nuts1: DE9
   - DE92:
-      name: Hannover
+      area_name: Hannover
       country: Germany
       nuts1: DE9
   - DE93:
-      name: Lüneburg
+      area_name: Lüneburg
       country: Germany
       nuts1: DE9
   - DE94:
-      name: Weser-Ems
+      area_name: Weser-Ems
       country: Germany
       nuts1: DE9
   - DEA1:
-      name: Düsseldorf
+      area_name: Düsseldorf
       country: Germany
       nuts1: DEA
   - DEA2:
-      name: Köln
+      area_name: Köln
       country: Germany
       nuts1: DEA
   - DEA3:
-      name: Münster
+      area_name: Münster
       country: Germany
       nuts1: DEA
   - DEA4:
-      name: Detmold
+      area_name: Detmold
       country: Germany
       nuts1: DEA
   - DEA5:
-      name: Arnsberg
+      area_name: Arnsberg
       country: Germany
       nuts1: DEA
   - DEB1:
-      name: Koblenz
+      area_name: Koblenz
       country: Germany
       nuts1: DEB
   - DEB2:
-      name: Trier
+      area_name: Trier
       country: Germany
       nuts1: DEB
   - DEB3:
-      name: Rheinhessen-Pfalz
+      area_name: Rheinhessen-Pfalz
       country: Germany
       nuts1: DEB
   - DEC0:
-      name: Saarland
+      area_name: Saarland
       country: Germany
       nuts1: DEC
   - DED2:
-      name: Dresden
+      area_name: Dresden
       country: Germany
       nuts1: DED
   - DED4:
-      name: Chemnitz
+      area_name: Chemnitz
       country: Germany
       nuts1: DED
   - DED5:
-      name: Leipzig
+      area_name: Leipzig
       country: Germany
       nuts1: DED
   - DEE0:
-      name: Sachsen-Anhalt
+      area_name: Sachsen-Anhalt
       country: Germany
       nuts1: DEE
   - DEF0:
-      name: Schleswig-Holstein
+      area_name: Schleswig-Holstein
       country: Germany
       nuts1: DEF
   - DEG0:
-      name: Thüringen
+      area_name: Thüringen
       country: Germany
       nuts1: DEG
   - DEZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Germany
       nuts1: DEZ
   - EE00:
-      name: Eesti
+      area_name: Eesti
       country: Estonia
       nuts1: EE0
   - EEZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Estonia
       nuts1: EEZ
   - IE04:
-      name: Northern and Western
+      area_name: Northern and Western
       country: Ireland
       nuts1: IE0
   - IE05:
-      name: Southern
+      area_name: Southern
       country: Ireland
       nuts1: IE0
   - IE06:
-      name: Eastern and Midland
+      area_name: Eastern and Midland
       country: Ireland
       nuts1: IE0
   - IEZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Ireland
       nuts1: IEZ
   - EL30:
-      name: Aττική
+      area_name: Aττική
       country: Greece
       nuts1: EL3
   - EL41:
-      name: Βόρειο Αιγαίο
+      area_name: Βόρειο Αιγαίο
       country: Greece
       nuts1: EL4
   - EL42:
-      name: Νότιο Αιγαίο
+      area_name: Νότιο Αιγαίο
       country: Greece
       nuts1: EL4
   - EL43:
-      name: Κρήτη
+      area_name: Κρήτη
       country: Greece
       nuts1: EL4
   - EL51:
-      name: Aνατολική Μακεδονία, Θράκη
+      area_name: Aνατολική Μακεδονία, Θράκη
       country: Greece
       nuts1: EL5
   - EL52:
-      name: Κεντρική Μακεδονία
+      area_name: Κεντρική Μακεδονία
       country: Greece
       nuts1: EL5
   - EL53:
-      name: Δυτική Μακεδονία
+      area_name: Δυτική Μακεδονία
       country: Greece
       nuts1: EL5
   - EL54:
-      name: Ήπειρος
+      area_name: Ήπειρος
       country: Greece
       nuts1: EL5
   - EL61:
-      name: Θεσσαλία
+      area_name: Θεσσαλία
       country: Greece
       nuts1: EL6
   - EL62:
-      name: Ιόνια Νησιά
+      area_name: Ιόνια Νησιά
       country: Greece
       nuts1: EL6
   - EL63:
-      name: Δυτική Ελλάδα
+      area_name: Δυτική Ελλάδα
       country: Greece
       nuts1: EL6
   - EL64:
-      name: Στερεά Ελλάδα
+      area_name: Στερεά Ελλάδα
       country: Greece
       nuts1: EL6
   - EL65:
-      name: Πελοπόννησος
+      area_name: Πελοπόννησος
       country: Greece
       nuts1: EL6
   - ELZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Greece
       nuts1: ELZ
   - ES11:
-      name: Galicia
+      area_name: Galicia
       country: Spain
       nuts1: ES1
   - ES12:
-      name: Principado de Asturias
+      area_name: Principado de Asturias
       country: Spain
       nuts1: ES1
   - ES13:
-      name: Cantabria
+      area_name: Cantabria
       country: Spain
       nuts1: ES1
   - ES21:
-      name: País Vasco
+      area_name: País Vasco
       country: Spain
       nuts1: ES2
   - ES22:
-      name: Comunidad Foral de Navarra
+      area_name: Comunidad Foral de Navarra
       country: Spain
       nuts1: ES2
   - ES23:
-      name: La Rioja
+      area_name: La Rioja
       country: Spain
       nuts1: ES2
   - ES24:
-      name: Aragón
+      area_name: Aragón
       country: Spain
       nuts1: ES2
   - ES30:
-      name: Comunidad de Madrid
+      area_name: Comunidad de Madrid
       country: Spain
       nuts1: ES3
   - ES41:
-      name: Castilla y León
+      area_name: Castilla y León
       country: Spain
       nuts1: ES4
   - ES42:
-      name: Castilla-La Mancha
+      area_name: Castilla-La Mancha
       country: Spain
       nuts1: ES4
   - ES43:
-      name: Extremadura
+      area_name: Extremadura
       country: Spain
       nuts1: ES4
   - ES51:
-      name: Cataluña
+      area_name: Cataluña
       country: Spain
       nuts1: ES5
   - ES52:
-      name: Comunitat Valenciana 
+      area_name: Comunitat Valenciana 
       country: Spain
       nuts1: ES5
   - ES53:
-      name: Illes Balears
+      area_name: Illes Balears
       country: Spain
       nuts1: ES5
   - ES61:
-      name: Andalucía
+      area_name: Andalucía
       country: Spain
       nuts1: ES6
   - ES62:
-      name: Región de Murcia
+      area_name: Región de Murcia
       country: Spain
       nuts1: ES6
   - ES63:
-      name: Ciudad de Ceuta
+      area_name: Ciudad de Ceuta
       country: Spain
       nuts1: ES6
   - ES64:
-      name: Ciudad de Melilla
+      area_name: Ciudad de Melilla
       country: Spain
       nuts1: ES6
   - ES70:
-      name: Canarias
+      area_name: Canarias
       country: Spain
       nuts1: ES7
   - ESZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Spain
       nuts1: ESZ
   - FR10:
-      name: Ile-de-France
+      area_name: Ile-de-France
       country: France
       nuts1: FR1
   - FRB0:
-      name: Centre — Val de Loire
+      area_name: Centre — Val de Loire
       country: France
       nuts1: FRB
   - FRC1:
-      name: Bourgogne
+      area_name: Bourgogne
       country: France
       nuts1: FRC
   - FRC2:
-      name: Franche-Comté
+      area_name: Franche-Comté
       country: France
       nuts1: FRC
   - FRD1:
-      name: Basse-Normandie 
+      area_name: Basse-Normandie 
       country: France
       nuts1: FRD
   - FRD2:
-      name: Haute-Normandie 
+      area_name: Haute-Normandie 
       country: France
       nuts1: FRD
   - FRE1:
-      name: Nord-Pas de Calais
+      area_name: Nord-Pas de Calais
       country: France
       nuts1: FRE
   - FRE2:
-      name: Picardie
+      area_name: Picardie
       country: France
       nuts1: FRE
   - FRF1:
-      name: Alsace
+      area_name: Alsace
       country: France
       nuts1: FRF
   - FRF2:
-      name: Champagne-Ardenne
+      area_name: Champagne-Ardenne
       country: France
       nuts1: FRF
   - FRF3:
-      name: Lorraine
+      area_name: Lorraine
       country: France
       nuts1: FRF
   - FRG0:
-      name: Pays de la Loire
+      area_name: Pays de la Loire
       country: France
       nuts1: FRG
   - FRH0:
-      name: Bretagne
+      area_name: Bretagne
       country: France
       nuts1: FRH
   - FRI1:
-      name: Aquitaine
+      area_name: Aquitaine
       country: France
       nuts1: FRI
   - FRI2:
-      name: Limousin
+      area_name: Limousin
       country: France
       nuts1: FRI
   - FRI3:
-      name: Poitou-Charentes
+      area_name: Poitou-Charentes
       country: France
       nuts1: FRI
   - FRJ1:
-      name: Languedoc-Roussillon
+      area_name: Languedoc-Roussillon
       country: France
       nuts1: FRJ
   - FRJ2:
-      name: Midi-Pyrénées
+      area_name: Midi-Pyrénées
       country: France
       nuts1: FRJ
   - FRK1:
-      name: Auvergne
+      area_name: Auvergne
       country: France
       nuts1: FRK
   - FRK2:
-      name: Rhône-Alpes
+      area_name: Rhône-Alpes
       country: France
       nuts1: FRK
   - FRL0:
-      name: Provence-Alpes-Côte d’Azur
+      area_name: Provence-Alpes-Côte d’Azur
       country: France
       nuts1: FRL
   - FRM0:
-      name: Corse
+      area_name: Corse
       country: France
       nuts1: FRM
   - FRY1:
-      name: Guadeloupe
+      area_name: Guadeloupe
       country: France
       nuts1: FRY
   - FRY2:
-      name: Martinique 
+      area_name: Martinique 
       country: France
       nuts1: FRY
   - FRY3:
-      name: Guyane
+      area_name: Guyane
       country: France
       nuts1: FRY
   - FRY4:
-      name: La Réunion 
+      area_name: La Réunion 
       country: France
       nuts1: FRY
   - FRY5:
-      name: Mayotte
+      area_name: Mayotte
       country: France
       nuts1: FRY
   - FRZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: France
       nuts1: FRZ
   - HR02:
-      name: Panonska Hrvatska
+      area_name: Panonska Hrvatska
       country: Croatia
       nuts1: HR0
   - HR03:
-      name: Jadranska Hrvatska
+      area_name: Jadranska Hrvatska
       country: Croatia
       nuts1: HR0
   - HR05:
-      name: Grad Zagreb
+      area_name: Grad Zagreb
       country: Croatia
       nuts1: HR0
   - HR06:
-      name: Sjeverna Hrvatska
+      area_name: Sjeverna Hrvatska
       country: Croatia
       nuts1: HR0
   - HRZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Croatia
       nuts1: HRZ
   - ITC1:
-      name: Piemonte
+      area_name: Piemonte
       country: Italy
       nuts1: ITC
   - ITC2:
-      name: Valle d’Aosta/Vallée d’Aoste
+      area_name: Valle d’Aosta/Vallée d’Aoste
       country: Italy
       nuts1: ITC
   - ITC3:
-      name: Liguria
+      area_name: Liguria
       country: Italy
       nuts1: ITC
   - ITC4:
-      name: Lombardia
+      area_name: Lombardia
       country: Italy
       nuts1: ITC
   - ITF1:
-      name: Abruzzo
+      area_name: Abruzzo
       country: Italy
       nuts1: ITF
   - ITF2:
-      name: Molise
+      area_name: Molise
       country: Italy
       nuts1: ITF
   - ITF3:
-      name: Campania
+      area_name: Campania
       country: Italy
       nuts1: ITF
   - ITF4:
-      name: Puglia
+      area_name: Puglia
       country: Italy
       nuts1: ITF
   - ITF5:
-      name: Basilicata
+      area_name: Basilicata
       country: Italy
       nuts1: ITF
   - ITF6:
-      name: Calabria
+      area_name: Calabria
       country: Italy
       nuts1: ITF
   - ITG1:
-      name: Sicilia
+      area_name: Sicilia
       country: Italy
       nuts1: ITG
   - ITG2:
-      name: Sardegna
+      area_name: Sardegna
       country: Italy
       nuts1: ITG
   - ITH1:
-      name: Provincia Autonoma di Bolzano/Bozen
+      area_name: Provincia Autonoma di Bolzano/Bozen
       country: Italy
       nuts1: ITH
   - ITH2:
-      name: Provincia Autonoma di Trento
+      area_name: Provincia Autonoma di Trento
       country: Italy
       nuts1: ITH
   - ITH3:
-      name: Veneto
+      area_name: Veneto
       country: Italy
       nuts1: ITH
   - ITH4:
-      name: Friuli-Venezia Giulia
+      area_name: Friuli-Venezia Giulia
       country: Italy
       nuts1: ITH
   - ITH5:
-      name: Emilia-Romagna
+      area_name: Emilia-Romagna
       country: Italy
       nuts1: ITH
   - ITI1:
-      name: Toscana
+      area_name: Toscana
       country: Italy
       nuts1: ITI
   - ITI2:
-      name: Umbria
+      area_name: Umbria
       country: Italy
       nuts1: ITI
   - ITI3:
-      name: Marche
+      area_name: Marche
       country: Italy
       nuts1: ITI
   - ITI4:
-      name: Lazio
+      area_name: Lazio
       country: Italy
       nuts1: ITI
   - ITZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Italy
       nuts1: ITZ
   - CY00:
-      name: Κύπρος
+      area_name: Κύπρος
       country: Cyprus
       nuts1: CY0
   - CYZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Cyprus
       nuts1: CYZ
   - LV00:
-      name: Latvija
+      area_name: Latvija
       country: Latvia
       nuts1: LV0
   - LVZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Latvia
       nuts1: LVZ
   - LT01:
-      name: Sostinės regionas
+      area_name: Sostinės regionas
       country: Lithuania
       nuts1: LT0
   - LT02:
-      name: Vidurio ir vakarų Lietuvos regionas 
+      area_name: Vidurio ir vakarų Lietuvos regionas 
       country: Lithuania
       nuts1: LT0
   - LTZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Lithuania
       nuts1: LTZ
   - LU00:
-      name: Luxembourg
+      area_name: Luxembourg
       country: Luxembourg
       nuts1: LU0
   - LUZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Luxembourg
       nuts1: LUZ
   - HU11:
-      name: Budapest
+      area_name: Budapest
       country: Hungary
       nuts1: HU1
   - HU12:
-      name: Pest
+      area_name: Pest
       country: Hungary
       nuts1: HU1
   - HU21:
-      name: Közép-Dunántúl
+      area_name: Közép-Dunántúl
       country: Hungary
       nuts1: HU2
   - HU22:
-      name: Nyugat-Dunántúl
+      area_name: Nyugat-Dunántúl
       country: Hungary
       nuts1: HU2
   - HU23:
-      name: Dél-Dunántúl
+      area_name: Dél-Dunántúl
       country: Hungary
       nuts1: HU2
   - HU31:
-      name: Észak-Magyarország
+      area_name: Észak-Magyarország
       country: Hungary
       nuts1: HU3
   - HU32:
-      name: Észak-Alföld
+      area_name: Észak-Alföld
       country: Hungary
       nuts1: HU3
   - HU33:
-      name: Dél-Alföld
+      area_name: Dél-Alföld
       country: Hungary
       nuts1: HU3
   - HUZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Hungary
       nuts1: HUZ
   - MT00:
-      name: Malta
+      area_name: Malta
       country: Malta
       nuts1: MT0
   - MTZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Malta
       nuts1: MTZ
   - NL11:
-      name: Groningen
+      area_name: Groningen
       country: The Netherlands
       nuts1: NL1
   - NL12:
-      name: Friesland (NL)
+      area_name: Friesland (NL)
       country: The Netherlands
       nuts1: NL1
   - NL13:
-      name: Drenthe
+      area_name: Drenthe
       country: The Netherlands
       nuts1: NL1
   - NL21:
-      name: Overijssel
+      area_name: Overijssel
       country: The Netherlands
       nuts1: NL2
   - NL22:
-      name: Gelderland
+      area_name: Gelderland
       country: The Netherlands
       nuts1: NL2
   - NL23:
-      name: Flevoland
+      area_name: Flevoland
       country: The Netherlands
       nuts1: NL2
   - NL31:
-      name: Utrecht
+      area_name: Utrecht
       country: The Netherlands
       nuts1: NL3
   - NL32:
-      name: Noord-Holland
+      area_name: Noord-Holland
       country: The Netherlands
       nuts1: NL3
   - NL33:
-      name: Zuid-Holland
+      area_name: Zuid-Holland
       country: The Netherlands
       nuts1: NL3
   - NL34:
-      name: Zeeland
+      area_name: Zeeland
       country: The Netherlands
       nuts1: NL3
   - NL41:
-      name: Noord-Brabant
+      area_name: Noord-Brabant
       country: The Netherlands
       nuts1: NL4
   - NL42:
-      name: Limburg (NL)
+      area_name: Limburg (NL)
       country: The Netherlands
       nuts1: NL4
   - NLZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: The Netherlands
       nuts1: NLZ
   - AT11:
-      name: Burgenland
+      area_name: Burgenland
       country: Austria
       nuts1: AT1
   - AT12:
-      name: Niederösterreich
+      area_name: Niederösterreich
       country: Austria
       nuts1: AT1
   - AT13:
-      name: Wien
+      area_name: Wien
       country: Austria
       nuts1: AT1
   - AT21:
-      name: Kärnten
+      area_name: Kärnten
       country: Austria
       nuts1: AT2
   - AT22:
-      name: Steiermark
+      area_name: Steiermark
       country: Austria
       nuts1: AT2
   - AT31:
-      name: Oberösterreich
+      area_name: Oberösterreich
       country: Austria
       nuts1: AT3
   - AT32:
-      name: Salzburg
+      area_name: Salzburg
       country: Austria
       nuts1: AT3
   - AT33:
-      name: Tirol
+      area_name: Tirol
       country: Austria
       nuts1: AT3
   - AT34:
-      name: Vorarlberg
+      area_name: Vorarlberg
       country: Austria
       nuts1: AT3
   - ATZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Austria
       nuts1: ATZ
   - PL21:
-      name: Małopolskie
+      area_name: Małopolskie
       country: Poland
       nuts1: PL2
   - PL22:
-      name: Śląskie
+      area_name: Śląskie
       country: Poland
       nuts1: PL2
   - PL41:
-      name: Wielkopolskie
+      area_name: Wielkopolskie
       country: Poland
       nuts1: PL4
   - PL42:
-      name: Zachodniopomorskie
+      area_name: Zachodniopomorskie
       country: Poland
       nuts1: PL4
   - PL43:
-      name: Lubuskie
+      area_name: Lubuskie
       country: Poland
       nuts1: PL4
   - PL51:
-      name: Dolnośląskie
+      area_name: Dolnośląskie
       country: Poland
       nuts1: PL5
   - PL52:
-      name: Opolskie
+      area_name: Opolskie
       country: Poland
       nuts1: PL5
   - PL61:
-      name: Kujawsko-pomorskie
+      area_name: Kujawsko-pomorskie
       country: Poland
       nuts1: PL6
   - PL62:
-      name: Warmińsko-mazurskie
+      area_name: Warmińsko-mazurskie
       country: Poland
       nuts1: PL6
   - PL63:
-      name: Pomorskie
+      area_name: Pomorskie
       country: Poland
       nuts1: PL6
   - PL71:
-      name: Łódzkie
+      area_name: Łódzkie
       country: Poland
       nuts1: PL7
   - PL72:
-      name: Świętokrzyskie
+      area_name: Świętokrzyskie
       country: Poland
       nuts1: PL7
   - PL81:
-      name: Lubelskie
+      area_name: Lubelskie
       country: Poland
       nuts1: PL8
   - PL82:
-      name: Podkarpackie
+      area_name: Podkarpackie
       country: Poland
       nuts1: PL8
   - PL84:
-      name: Podlaskie
+      area_name: Podlaskie
       country: Poland
       nuts1: PL8
   - PL91:
-      name: Warszawski stołeczny
+      area_name: Warszawski stołeczny
       country: Poland
       nuts1: PL9
   - PL92:
-      name: Mazowiecki regionalny
+      area_name: Mazowiecki regionalny
       country: Poland
       nuts1: PL9
   - PLZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Poland
       nuts1: PLZ
   - PT11:
-      name: Norte
+      area_name: Norte
       country: Portugal
       nuts1: PT1
   - PT15:
-      name: Algarve
+      area_name: Algarve
       country: Portugal
       nuts1: PT1
   - PT16:
-      name: Centro (PT)
+      area_name: Centro (PT)
       country: Portugal
       nuts1: PT1
   - PT17:
-      name: Área Metropolitana de Lisboa
+      area_name: Área Metropolitana de Lisboa
       country: Portugal
       nuts1: PT1
   - PT18:
-      name: Alentejo
+      area_name: Alentejo
       country: Portugal
       nuts1: PT1
   - PT20:
-      name: Região Autónoma dos Açores
+      area_name: Região Autónoma dos Açores
       country: Portugal
       nuts1: PT2
   - PT30:
-      name: Região Autónoma da Madeira
+      area_name: Região Autónoma da Madeira
       country: Portugal
       nuts1: PT3
   - PTZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Portugal
       nuts1: PTZ
   - RO11:
-      name: Nord-Vest
+      area_name: Nord-Vest
       country: Romania
       nuts1: RO1
   - RO12:
-      name: Centru
+      area_name: Centru
       country: Romania
       nuts1: RO1
   - RO21:
-      name: Nord-Est
+      area_name: Nord-Est
       country: Romania
       nuts1: RO2
   - RO22:
-      name: Sud-Est
+      area_name: Sud-Est
       country: Romania
       nuts1: RO2
   - RO31:
-      name: Sud-Muntenia
+      area_name: Sud-Muntenia
       country: Romania
       nuts1: RO3
   - RO32:
-      name: Bucureşti-Ilfov
+      area_name: Bucureşti-Ilfov
       country: Romania
       nuts1: RO3
   - RO41:
-      name: Sud-Vest Oltenia
+      area_name: Sud-Vest Oltenia
       country: Romania
       nuts1: RO4
   - RO42:
-      name: Vest
+      area_name: Vest
       country: Romania
       nuts1: RO4
   - ROZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Romania
       nuts1: ROZ
   - SI03:
-      name: Vzhodna Slovenija
+      area_name: Vzhodna Slovenija
       country: Slovenia
       nuts1: SI0
   - SI04:
-      name: Zahodna Slovenija
+      area_name: Zahodna Slovenija
       country: Slovenia
       nuts1: SI0
   - SIZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Slovenia
       nuts1: SIZ
   - SK01:
-      name: Bratislavský kraj
+      area_name: Bratislavský kraj
       country: Slovakia
       nuts1: SK0
   - SK02:
-      name: Západné Slovensko
+      area_name: Západné Slovensko
       country: Slovakia
       nuts1: SK0
   - SK03:
-      name: Stredné Slovensko
+      area_name: Stredné Slovensko
       country: Slovakia
       nuts1: SK0
   - SK04:
-      name: Východné Slovensko
+      area_name: Východné Slovensko
       country: Slovakia
       nuts1: SK0
   - SKZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Slovakia
       nuts1: SKZ
   - FI19:
-      name: Länsi-Suomi
+      area_name: Länsi-Suomi
       country: Finland
       nuts1: FI1
   - FI1B:
-      name: Helsinki-Uusimaa
+      area_name: Helsinki-Uusimaa
       country: Finland
       nuts1: FI1
   - FI1C:
-      name: Etelä-Suomi
+      area_name: Etelä-Suomi
       country: Finland
       nuts1: FI1
   - FI1D:
-      name: Pohjois- ja Itä-Suomi
+      area_name: Pohjois- ja Itä-Suomi
       country: Finland
       nuts1: FI1
   - FI20:
-      name: Åland
+      area_name: Åland
       country: Finland
       nuts1: FI2
   - FIZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Finland
       nuts1: FIZ
   - SE11:
-      name: Stockholm
+      area_name: Stockholm
       country: Sweden
       nuts1: SE1
   - SE12:
-      name: Östra Mellansverige
+      area_name: Östra Mellansverige
       country: Sweden
       nuts1: SE1
   - SE21:
-      name: Småland med öarna
+      area_name: Småland med öarna
       country: Sweden
       nuts1: SE2
   - SE22:
-      name: Sydsverige
+      area_name: Sydsverige
       country: Sweden
       nuts1: SE2
   - SE23:
-      name: Västsverige
+      area_name: Västsverige
       country: Sweden
       nuts1: SE2
   - SE31:
-      name: Norra Mellansverige
+      area_name: Norra Mellansverige
       country: Sweden
       nuts1: SE3
   - SE32:
-      name: Mellersta Norrland
+      area_name: Mellersta Norrland
       country: Sweden
       nuts1: SE3
   - SE33:
-      name: Övre Norrland
+      area_name: Övre Norrland
       country: Sweden
       nuts1: SE3
   - SEZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Sweden
       nuts1: SEZ
   - UKC1:
-      name: Tees Valley and Durham
+      area_name: Tees Valley and Durham
       country: United Kingdom
       nuts1: UKC
   - UKC2:
-      name: Northumberland and Tyne and Wear
+      area_name: Northumberland and Tyne and Wear
       country: United Kingdom
       nuts1: UKC
   - UKD1:
-      name: Cumbria
+      area_name: Cumbria
       country: United Kingdom
       nuts1: UKD
   - UKD3:
-      name: Greater Manchester
+      area_name: Greater Manchester
       country: United Kingdom
       nuts1: UKD
   - UKD4:
-      name: Lancashire
+      area_name: Lancashire
       country: United Kingdom
       nuts1: UKD
   - UKD6:
-      name: Cheshire
+      area_name: Cheshire
       country: United Kingdom
       nuts1: UKD
   - UKD7:
-      name: Merseyside
+      area_name: Merseyside
       country: United Kingdom
       nuts1: UKD
   - UKE1:
-      name: East Yorkshire and Northern Lincolnshire
+      area_name: East Yorkshire and Northern Lincolnshire
       country: United Kingdom
       nuts1: UKE
   - UKE2:
-      name: North Yorkshire
+      area_name: North Yorkshire
       country: United Kingdom
       nuts1: UKE
   - UKE3:
-      name: South Yorkshire
+      area_name: South Yorkshire
       country: United Kingdom
       nuts1: UKE
   - UKE4:
-      name: West Yorkshire
+      area_name: West Yorkshire
       country: United Kingdom
       nuts1: UKE
   - UKF1:
-      name: Derbyshire and Nottinghamshire
+      area_name: Derbyshire and Nottinghamshire
       country: United Kingdom
       nuts1: UKF
   - UKF2:
-      name: Leicestershire, Rutland and Northamptonshire
+      area_name: Leicestershire, Rutland and Northamptonshire
       country: United Kingdom
       nuts1: UKF
   - UKF3:
-      name: Lincolnshire
+      area_name: Lincolnshire
       country: United Kingdom
       nuts1: UKF
   - UKG1:
-      name: Herefordshire, Worcestershire and Warwickshire
+      area_name: Herefordshire, Worcestershire and Warwickshire
       country: United Kingdom
       nuts1: UKG
   - UKG2:
-      name: Shropshire and Staffordshire
+      area_name: Shropshire and Staffordshire
       country: United Kingdom
       nuts1: UKG
   - UKG3:
-      name: West Midlands
+      area_name: West Midlands
       country: United Kingdom
       nuts1: UKG
   - UKH1:
-      name: East Anglia
+      area_name: East Anglia
       country: United Kingdom
       nuts1: UKH
   - UKH2:
-      name: Bedfordshire and Hertfordshire
+      area_name: Bedfordshire and Hertfordshire
       country: United Kingdom
       nuts1: UKH
   - UKH3:
-      name: Essex
+      area_name: Essex
       country: United Kingdom
       nuts1: UKH
   - UKI3:
-      name: Inner London — West
+      area_name: Inner London — West
       country: United Kingdom
       nuts1: UKI
   - UKI4:
-      name: Inner London — East
+      area_name: Inner London — East
       country: United Kingdom
       nuts1: UKI
   - UKI5:
-      name: Outer London — East and North East
+      area_name: Outer London — East and North East
       country: United Kingdom
       nuts1: UKI
   - UKI6:
-      name: Outer London — South
+      area_name: Outer London — South
       country: United Kingdom
       nuts1: UKI
   - UKI7:
-      name: Outer London — West and North West
+      area_name: Outer London — West and North West
       country: United Kingdom
       nuts1: UKI
   - UKJ1:
-      name: Berkshire, Buckinghamshire and Oxfordshire
+      area_name: Berkshire, Buckinghamshire and Oxfordshire
       country: United Kingdom
       nuts1: UKJ
   - UKJ2:
-      name: Surrey, East and West Sussex
+      area_name: Surrey, East and West Sussex
       country: United Kingdom
       nuts1: UKJ
   - UKJ3:
-      name: Hampshire and Isle of Wight
+      area_name: Hampshire and Isle of Wight
       country: United Kingdom
       nuts1: UKJ
   - UKJ4:
-      name: Kent
+      area_name: Kent
       country: United Kingdom
       nuts1: UKJ
   - UKK1:
-      name: Gloucestershire, Wiltshire and Bristol/Bath area
+      area_name: Gloucestershire, Wiltshire and Bristol/Bath area
       country: United Kingdom
       nuts1: UKK
   - UKK2:
-      name: Dorset and Somerset
+      area_name: Dorset and Somerset
       country: United Kingdom
       nuts1: UKK
   - UKK3:
-      name: Cornwall and Isles of Scilly
+      area_name: Cornwall and Isles of Scilly
       country: United Kingdom
       nuts1: UKK
   - UKK4:
-      name: Devon
+      area_name: Devon
       country: United Kingdom
       nuts1: UKK
   - UKL1:
-      name: West Wales and The Valleys
+      area_name: West Wales and The Valleys
       country: United Kingdom
       nuts1: UKL
   - UKL2:
-      name: East Wales
+      area_name: East Wales
       country: United Kingdom
       nuts1: UKL
   - UKM5:
-      name: North Eastern Scotland
+      area_name: North Eastern Scotland
       country: United Kingdom
       nuts1: UKM
   - UKM6:
-      name: Highlands and Islands
+      area_name: Highlands and Islands
       country: United Kingdom
       nuts1: UKM
   - UKM7:
-      name: Eastern Scotland
+      area_name: Eastern Scotland
       country: United Kingdom
       nuts1: UKM
   - UKM8:
-      name: West Central Scotland
+      area_name: West Central Scotland
       country: United Kingdom
       nuts1: UKM
   - UKM9:
-      name: Southern Scotland
+      area_name: Southern Scotland
       country: United Kingdom
       nuts1: UKM
   - UKN0:
-      name: Northern Ireland
+      area_name: Northern Ireland
       country: United Kingdom
       nuts1: UKN
   - UKZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: United Kingdom
       nuts1: UKZ
   - IS00:
-      name: Ísland
+      area_name: Ísland
       country: Iceland
       nuts1: IS0
   - ISZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Iceland
       nuts1: ISZ
   - LI00:
-      name: Liechtenstein
+      area_name: Liechtenstein
       country: Liechtenstein
       nuts1: LI0
   - LIZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Liechtenstein
       nuts1: LIZ
   - NO02:
-      name: Innlandet
+      area_name: Innlandet
       country: Norway
       nuts1: NO0
   - NO06:
-      name: Trøndelag
+      area_name: Trøndelag
       country: Norway
       nuts1: NO0
   - NO07:
-      name: Nord-Norge
+      area_name: Nord-Norge
       country: Norway
       nuts1: NO0
   - NO08:
-      name: Oslo og Viken
+      area_name: Oslo og Viken
       country: Norway
       nuts1: NO0
   - NO09:
-      name: Agder og Sør-Østlandet
+      area_name: Agder og Sør-Østlandet
       country: Norway
       nuts1: NO0
   - NO0A:
-      name: Vestlandet
+      area_name: Vestlandet
       country: Norway
       nuts1: NO0
   - NO0B:
-      name: Jan Mayen and Svalbard
+      area_name: Jan Mayen and Svalbard
       country: Norway
       nuts1: NO0
   - NOZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Norway
       nuts1: NOZ
   - CH01:
-      name: Région lémanique
+      area_name: Région lémanique
       country: Switzerland
       nuts1: CH0
   - CH02:
-      name: Espace Mittelland
+      area_name: Espace Mittelland
       country: Switzerland
       nuts1: CH0
   - CH03:
-      name: Nordwestschweiz
+      area_name: Nordwestschweiz
       country: Switzerland
       nuts1: CH0
   - CH04:
-      name: Zürich
+      area_name: Zürich
       country: Switzerland
       nuts1: CH0
   - CH05:
-      name: Ostschweiz
+      area_name: Ostschweiz
       country: Switzerland
       nuts1: CH0
   - CH06:
-      name: Zentralschweiz
+      area_name: Zentralschweiz
       country: Switzerland
       nuts1: CH0
   - CH07:
-      name: Ticino
+      area_name: Ticino
       country: Switzerland
       nuts1: CH0
   - CHZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Switzerland
       nuts1: CHZ
   - ME00:
-      name: Црна Гора
+      area_name: Црна Гора
       country: Montenegro
       nuts1: ME0
   - MEZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Montenegro
       nuts1: MEZ
   - MK00:
-      name: Северна Македонија
+      area_name: Северна Македонија
       country: North Macedonia
       nuts1: MK0
   - MKZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: North Macedonia
       nuts1: MKZ
   - AL01:
-      name: Veri
+      area_name: Veri
       country: Albania
       nuts1: AL0
   - AL02:
-      name: Qender
+      area_name: Qender
       country: Albania
       nuts1: AL0
   - AL03:
-      name: Jug
+      area_name: Jug
       country: Albania
       nuts1: AL0
   - ALZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Albania
       nuts1: ALZ
   - RS11:
-      name: Београдски регион
+      area_name: Београдски регион
       country: Serbia
       nuts1: RS1
   - RS12:
-      name: Регион Војводине
+      area_name: Регион Војводине
       country: Serbia
       nuts1: RS1
   - RS21:
-      name: Регион Шумадије и Западне Србије
+      area_name: Регион Шумадије и Западне Србије
       country: Serbia
       nuts1: RS2
   - RS22:
-      name: Регион Јужне и Источне Србије
+      area_name: Регион Јужне и Источне Србије
       country: Serbia
       nuts1: RS2
   - RSZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Serbia
       nuts1: RSZ
   - TR10 :
-      name: İstanbul
+      area_name: İstanbul
       country: Turkey
       nuts1: TR1
   - TR21:
-      name: Tekirdağ, Edirne, Kırklareli
+      area_name: Tekirdağ, Edirne, Kırklareli
       country: Turkey
       nuts1: TR2
   - TR22:
-      name: Balıkesir, Çanakkale
+      area_name: Balıkesir, Çanakkale
       country: Turkey
       nuts1: TR2
   - TR31:
-      name: İzmir
+      area_name: İzmir
       country: Turkey
       nuts1: TR3
   - TR32:
-      name: Aydın, Denizli, Muğla
+      area_name: Aydın, Denizli, Muğla
       country: Turkey
       nuts1: TR3
   - TR33:
-      name: Manisa, Afyonkarahisar, Kütahya, Uşak
+      area_name: Manisa, Afyonkarahisar, Kütahya, Uşak
       country: Turkey
       nuts1: TR3
   - TR41:
-      name: Bursa, Eskişehir, Bilecik
+      area_name: Bursa, Eskişehir, Bilecik
       country: Turkey
       nuts1: TR4
   - TR42:
-      name: Kocaeli, Sakarya, Düzce, Bolu, Yalova
+      area_name: Kocaeli, Sakarya, Düzce, Bolu, Yalova
       country: Turkey
       nuts1: TR4
   - TR51:
-      name: Ankara
+      area_name: Ankara
       country: Turkey
       nuts1: TR5
   - TR52:
-      name: Konya, Karaman
+      area_name: Konya, Karaman
       country: Turkey
       nuts1: TR5
   - TR61:
-      name: Antalya, Isparta, Burdur
+      area_name: Antalya, Isparta, Burdur
       country: Turkey
       nuts1: TR6
   - TR62:
-      name: Adana, Mersin
+      area_name: Adana, Mersin
       country: Turkey
       nuts1: TR6
   - TR63:
-      name: Hatay, Kahramanmaraş, Osmaniye
+      area_name: Hatay, Kahramanmaraş, Osmaniye
       country: Turkey
       nuts1: TR6
   - TR71:
-      name: Kırıkkale, Aksaray, Niğde, Nevşehir, Kırşehir
+      area_name: Kırıkkale, Aksaray, Niğde, Nevşehir, Kırşehir
       country: Turkey
       nuts1: TR7
   - TR72:
-      name: Kayseri, Sivas, Yozgat
+      area_name: Kayseri, Sivas, Yozgat
       country: Turkey
       nuts1: TR7
   - TR81:
-      name: Zonguldak, Karabük, Bartın
+      area_name: Zonguldak, Karabük, Bartın
       country: Turkey
       nuts1: TR8
   - TR82:
-      name: Kastamonu, Çankırı, Sinop
+      area_name: Kastamonu, Çankırı, Sinop
       country: Turkey
       nuts1: TR8
   - TR83:
-      name: Samsun, Tokat, Çorum, Amasya
+      area_name: Samsun, Tokat, Çorum, Amasya
       country: Turkey
       nuts1: TR8
   - TR90 :
-      name: Trabzon, Ordu, Giresun, Rize, Artvin, Gümüşhane
+      area_name: Trabzon, Ordu, Giresun, Rize, Artvin, Gümüşhane
       country: Turkey
       nuts1: TR9
   - TRA1:
-      name: Erzurum, Erzincan, Bayburt
+      area_name: Erzurum, Erzincan, Bayburt
       country: Turkey
       nuts1: TRA
   - TRA2:
-      name: Ağrı, Kars, Iğdır, Ardahan
+      area_name: Ağrı, Kars, Iğdır, Ardahan
       country: Turkey
       nuts1: TRA
   - TRB1:
-      name: Malatya, Elazığ, Bingöl, Tunceli
+      area_name: Malatya, Elazığ, Bingöl, Tunceli
       country: Turkey
       nuts1: TRB
   - TRB2:
-      name: Van, Muş, Bitlis, Hakkari
+      area_name: Van, Muş, Bitlis, Hakkari
       country: Turkey
       nuts1: TRB
   - TRC1:
-      name: Gaziantep, Adıyaman, Kilis
+      area_name: Gaziantep, Adıyaman, Kilis
       country: Turkey
       nuts1: TRC
   - TRC2:
-      name: Şanlıurfa, Diyarbakır
+      area_name: Şanlıurfa, Diyarbakır
       country: Turkey
       nuts1: TRC
   - TRC3:
-      name: Mardin, Batman, Şırnak, Siirt
+      area_name: Mardin, Batman, Şırnak, Siirt
       country: Turkey
       nuts1: TRC
   - TRZZ:
-      name: Extra-Regio NUTS 2
+      area_name: Extra-Regio NUTS 2
       country: Turkey
       nuts1: TRZ

--- a/definitions/region/nuts3.yaml
+++ b/definitions/region/nuts3.yaml
@@ -4,7757 +4,7757 @@
 # List of NUTS3 regions: small regions for specific diagnoses
 - NUTS3:
   - BE100:
-      name: Arr. de Bruxelles-Capitale/Arr. Brussel-Hoofdstad
+      area_name: Arr. de Bruxelles-Capitale/Arr. Brussel-Hoofdstad
       country: Belgium
       nuts1: BE1
       nuts2: BE10
   - BE211:
-      name: Arr. Antwerpen
+      area_name: Arr. Antwerpen
       country: Belgium
       nuts1: BE2
       nuts2: BE21
   - BE212:
-      name: Arr. Mechelen
+      area_name: Arr. Mechelen
       country: Belgium
       nuts1: BE2
       nuts2: BE21
   - BE213:
-      name: Arr. Turnhout
+      area_name: Arr. Turnhout
       country: Belgium
       nuts1: BE2
       nuts2: BE21
   - BE223:
-      name: Arr. Tongeren
+      area_name: Arr. Tongeren
       country: Belgium
       nuts1: BE2
       nuts2: BE22
   - BE224:
-      name: Arr. Hasselt
+      area_name: Arr. Hasselt
       country: Belgium
       nuts1: BE2
       nuts2: BE22
   - BE225:
-      name: Arr. Maaseik
+      area_name: Arr. Maaseik
       country: Belgium
       nuts1: BE2
       nuts2: BE22
   - BE231:
-      name: Arr. Aalst
+      area_name: Arr. Aalst
       country: Belgium
       nuts1: BE2
       nuts2: BE23
   - BE232:
-      name: Arr. Dendermonde
+      area_name: Arr. Dendermonde
       country: Belgium
       nuts1: BE2
       nuts2: BE23
   - BE233:
-      name: Arr. Eeklo
+      area_name: Arr. Eeklo
       country: Belgium
       nuts1: BE2
       nuts2: BE23
   - BE234:
-      name: Arr. Gent
+      area_name: Arr. Gent
       country: Belgium
       nuts1: BE2
       nuts2: BE23
   - BE235:
-      name: Arr. Oudenaarde
+      area_name: Arr. Oudenaarde
       country: Belgium
       nuts1: BE2
       nuts2: BE23
   - BE236:
-      name: Arr. Sint-Niklaas
+      area_name: Arr. Sint-Niklaas
       country: Belgium
       nuts1: BE2
       nuts2: BE23
   - BE241:
-      name: Arr. Halle-Vilvoorde
+      area_name: Arr. Halle-Vilvoorde
       country: Belgium
       nuts1: BE2
       nuts2: BE24
   - BE242:
-      name: Arr. Leuven
+      area_name: Arr. Leuven
       country: Belgium
       nuts1: BE2
       nuts2: BE24
   - BE251:
-      name: Arr. Brugge
+      area_name: Arr. Brugge
       country: Belgium
       nuts1: BE2
       nuts2: BE25
   - BE252:
-      name: Arr. Diksmuide
+      area_name: Arr. Diksmuide
       country: Belgium
       nuts1: BE2
       nuts2: BE25
   - BE253:
-      name: Arr. Ieper
+      area_name: Arr. Ieper
       country: Belgium
       nuts1: BE2
       nuts2: BE25
   - BE254:
-      name: Arr. Kortrijk
+      area_name: Arr. Kortrijk
       country: Belgium
       nuts1: BE2
       nuts2: BE25
   - BE255:
-      name: Arr. Oostende
+      area_name: Arr. Oostende
       country: Belgium
       nuts1: BE2
       nuts2: BE25
   - BE256:
-      name: Arr. Roeselare
+      area_name: Arr. Roeselare
       country: Belgium
       nuts1: BE2
       nuts2: BE25
   - BE257:
-      name: Arr. Tielt
+      area_name: Arr. Tielt
       country: Belgium
       nuts1: BE2
       nuts2: BE25
   - BE258:
-      name: Arr. Veurne
+      area_name: Arr. Veurne
       country: Belgium
       nuts1: BE2
       nuts2: BE25
   - BE310:
-      name: Arr. Nivelles
+      area_name: Arr. Nivelles
       country: Belgium
       nuts1: BE3
       nuts2: BE31
   - BE323:
-      name: Arr. Mons
+      area_name: Arr. Mons
       country: Belgium
       nuts1: BE3
       nuts2: BE32
   - BE328:
-      name: Arr. Tournai-Mouscron
+      area_name: Arr. Tournai-Mouscron
       country: Belgium
       nuts1: BE3
       nuts2: BE32
   - BE329:
-      name: Arr. La Louvière
+      area_name: Arr. La Louvière
       country: Belgium
       nuts1: BE3
       nuts2: BE32
   - BE32A:
-      name: Arr. Ath
+      area_name: Arr. Ath
       country: Belgium
       nuts1: BE3
       nuts2: BE32
   - BE32B:
-      name: Arr. Charleroi
+      area_name: Arr. Charleroi
       country: Belgium
       nuts1: BE3
       nuts2: BE32
   - BE32C:
-      name: Arr. Soignies
+      area_name: Arr. Soignies
       country: Belgium
       nuts1: BE3
       nuts2: BE32
   - BE32D:
-      name: Arr. Thuin
+      area_name: Arr. Thuin
       country: Belgium
       nuts1: BE3
       nuts2: BE32
   - BE331:
-      name: Arr. Huy
+      area_name: Arr. Huy
       country: Belgium
       nuts1: BE3
       nuts2: BE33
   - BE332:
-      name: Arr. Liège
+      area_name: Arr. Liège
       country: Belgium
       nuts1: BE3
       nuts2: BE33
   - BE334:
-      name: Arr. Waremme
+      area_name: Arr. Waremme
       country: Belgium
       nuts1: BE3
       nuts2: BE33
   - BE335:
-      name: Arr. Verviers — communes francophones
+      area_name: Arr. Verviers — communes francophones
       country: Belgium
       nuts1: BE3
       nuts2: BE33
   - BE336:
-      name: Bezirk Verviers — Deutschsprachige Gemeinschaft
+      area_name: Bezirk Verviers — Deutschsprachige Gemeinschaft
       country: Belgium
       nuts1: BE3
       nuts2: BE33
   - BE341:
-      name: Arr. Arlon
+      area_name: Arr. Arlon
       country: Belgium
       nuts1: BE3
       nuts2: BE34
   - BE342:
-      name: Arr. Bastogne
+      area_name: Arr. Bastogne
       country: Belgium
       nuts1: BE3
       nuts2: BE34
   - BE343:
-      name: Arr. Marche-en-Famenne
+      area_name: Arr. Marche-en-Famenne
       country: Belgium
       nuts1: BE3
       nuts2: BE34
   - BE344:
-      name: Arr. Neufchâteau
+      area_name: Arr. Neufchâteau
       country: Belgium
       nuts1: BE3
       nuts2: BE34
   - BE345:
-      name: Arr. Virton
+      area_name: Arr. Virton
       country: Belgium
       nuts1: BE3
       nuts2: BE34
   - BE351:
-      name: Arr. Dinant
+      area_name: Arr. Dinant
       country: Belgium
       nuts1: BE3
       nuts2: BE35
   - BE352:
-      name: Arr. Namur
+      area_name: Arr. Namur
       country: Belgium
       nuts1: BE3
       nuts2: BE35
   - BE353:
-      name: Arr. Philippeville
+      area_name: Arr. Philippeville
       country: Belgium
       nuts1: BE3
       nuts2: BE35
   - BEZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Belgium
       nuts1: BEZ
       nuts2: BEZZ
   - BG311:
-      name: Видин
+      area_name: Видин
       country: Bulgaria
       nuts1: BG3
       nuts2: BG31
   - BG312:
-      name: Монтана
+      area_name: Монтана
       country: Bulgaria
       nuts1: BG3
       nuts2: BG31
   - BG313:
-      name: Враца
+      area_name: Враца
       country: Bulgaria
       nuts1: BG3
       nuts2: BG31
   - BG314:
-      name: Плевен
+      area_name: Плевен
       country: Bulgaria
       nuts1: BG3
       nuts2: BG31
   - BG315:
-      name: Ловеч
+      area_name: Ловеч
       country: Bulgaria
       nuts1: BG3
       nuts2: BG31
   - BG321:
-      name: Велико Търново
+      area_name: Велико Търново
       country: Bulgaria
       nuts1: BG3
       nuts2: BG32
   - BG322:
-      name: Габрово
+      area_name: Габрово
       country: Bulgaria
       nuts1: BG3
       nuts2: BG32
   - BG323:
-      name: Русе
+      area_name: Русе
       country: Bulgaria
       nuts1: BG3
       nuts2: BG32
   - BG324:
-      name: Разград
+      area_name: Разград
       country: Bulgaria
       nuts1: BG3
       nuts2: BG32
   - BG325:
-      name: Силистра
+      area_name: Силистра
       country: Bulgaria
       nuts1: BG3
       nuts2: BG32
   - BG331:
-      name: Варна
+      area_name: Варна
       country: Bulgaria
       nuts1: BG3
       nuts2: BG33
   - BG332:
-      name: Добрич
+      area_name: Добрич
       country: Bulgaria
       nuts1: BG3
       nuts2: BG33
   - BG333:
-      name: Шумен
+      area_name: Шумен
       country: Bulgaria
       nuts1: BG3
       nuts2: BG33
   - BG334:
-      name: Търговище
+      area_name: Търговище
       country: Bulgaria
       nuts1: BG3
       nuts2: BG33
   - BG341:
-      name: Бургас
+      area_name: Бургас
       country: Bulgaria
       nuts1: BG3
       nuts2: BG34
   - BG342:
-      name: Сливен
+      area_name: Сливен
       country: Bulgaria
       nuts1: BG3
       nuts2: BG34
   - BG343:
-      name: Ямбол
+      area_name: Ямбол
       country: Bulgaria
       nuts1: BG3
       nuts2: BG34
   - BG344:
-      name: Стара Загора
+      area_name: Стара Загора
       country: Bulgaria
       nuts1: BG3
       nuts2: BG34
   - BG411:
-      name: София (столица)
+      area_name: София (столица)
       country: Bulgaria
       nuts1: BG4
       nuts2: BG41
   - BG412:
-      name: София
+      area_name: София
       country: Bulgaria
       nuts1: BG4
       nuts2: BG41
   - BG413:
-      name: Благоевград
+      area_name: Благоевград
       country: Bulgaria
       nuts1: BG4
       nuts2: BG41
   - BG414:
-      name: Перник
+      area_name: Перник
       country: Bulgaria
       nuts1: BG4
       nuts2: BG41
   - BG415:
-      name: Кюстендил
+      area_name: Кюстендил
       country: Bulgaria
       nuts1: BG4
       nuts2: BG41
   - BG421:
-      name: Пловдив
+      area_name: Пловдив
       country: Bulgaria
       nuts1: BG4
       nuts2: BG42
   - BG422:
-      name: Хасково
+      area_name: Хасково
       country: Bulgaria
       nuts1: BG4
       nuts2: BG42
   - BG423:
-      name: Пазарджик
+      area_name: Пазарджик
       country: Bulgaria
       nuts1: BG4
       nuts2: BG42
   - BG424:
-      name: Смолян
+      area_name: Смолян
       country: Bulgaria
       nuts1: BG4
       nuts2: BG42
   - BG425:
-      name: Кърджали
+      area_name: Кърджали
       country: Bulgaria
       nuts1: BG4
       nuts2: BG42
   - BGZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Bulgaria
       nuts1: BGZ
       nuts2: BGZZ
   - CZ010:
-      name: Hlavní město Praha
+      area_name: Hlavní město Praha
       country: Czech Republic
       nuts1: CZ0
       nuts2: CZ01
   - CZ020:
-      name: Středočeský kraj
+      area_name: Středočeský kraj
       country: Czech Republic
       nuts1: CZ0
       nuts2: CZ02
   - CZ031:
-      name: Jihočeský kraj
+      area_name: Jihočeský kraj
       country: Czech Republic
       nuts1: CZ0
       nuts2: CZ03
   - CZ032:
-      name: Plzeňský kraj
+      area_name: Plzeňský kraj
       country: Czech Republic
       nuts1: CZ0
       nuts2: CZ03
   - CZ041:
-      name: Karlovarský kraj
+      area_name: Karlovarský kraj
       country: Czech Republic
       nuts1: CZ0
       nuts2: CZ04
   - CZ042:
-      name: Ústecký kraj
+      area_name: Ústecký kraj
       country: Czech Republic
       nuts1: CZ0
       nuts2: CZ04
   - CZ051:
-      name: Liberecký kraj
+      area_name: Liberecký kraj
       country: Czech Republic
       nuts1: CZ0
       nuts2: CZ05
   - CZ052:
-      name: Královéhradecký kraj
+      area_name: Královéhradecký kraj
       country: Czech Republic
       nuts1: CZ0
       nuts2: CZ05
   - CZ053:
-      name: Pardubický kraj
+      area_name: Pardubický kraj
       country: Czech Republic
       nuts1: CZ0
       nuts2: CZ05
   - CZ063:
-      name: Kraj Vysočina
+      area_name: Kraj Vysočina
       country: Czech Republic
       nuts1: CZ0
       nuts2: CZ06
   - CZ064:
-      name: Jihomoravský kraj
+      area_name: Jihomoravský kraj
       country: Czech Republic
       nuts1: CZ0
       nuts2: CZ06
   - CZ071:
-      name: Olomoucký kraj
+      area_name: Olomoucký kraj
       country: Czech Republic
       nuts1: CZ0
       nuts2: CZ07
   - CZ072:
-      name: Zlínský kraj
+      area_name: Zlínský kraj
       country: Czech Republic
       nuts1: CZ0
       nuts2: CZ07
   - CZ080:
-      name: Moravskoslezský kraj
+      area_name: Moravskoslezský kraj
       country: Czech Republic
       nuts1: CZ0
       nuts2: CZ08
   - CZZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Czech Republic
       nuts1: CZZ
       nuts2: CZZZ
   - DK011:
-      name: Byen København
+      area_name: Byen København
       country: Denmark
       nuts1: DK0
       nuts2: DK01
   - DK012:
-      name: Københavns omegn
+      area_name: Københavns omegn
       country: Denmark
       nuts1: DK0
       nuts2: DK01
   - DK013:
-      name: Nordsjælland
+      area_name: Nordsjælland
       country: Denmark
       nuts1: DK0
       nuts2: DK01
   - DK014:
-      name: Bornholm
+      area_name: Bornholm
       country: Denmark
       nuts1: DK0
       nuts2: DK01
   - DK021:
-      name: Østsjælland
+      area_name: Østsjælland
       country: Denmark
       nuts1: DK0
       nuts2: DK02
   - DK022:
-      name: Vest- og Sydsjælland
+      area_name: Vest- og Sydsjælland
       country: Denmark
       nuts1: DK0
       nuts2: DK02
   - DK031:
-      name: Fyn
+      area_name: Fyn
       country: Denmark
       nuts1: DK0
       nuts2: DK03
   - DK032:
-      name: Sydjylland
+      area_name: Sydjylland
       country: Denmark
       nuts1: DK0
       nuts2: DK03
   - DK041:
-      name: Vestjylland
+      area_name: Vestjylland
       country: Denmark
       nuts1: DK0
       nuts2: DK04
   - DK042:
-      name: Østjylland
+      area_name: Østjylland
       country: Denmark
       nuts1: DK0
       nuts2: DK04
   - DK050:
-      name: Nordjylland
+      area_name: Nordjylland
       country: Denmark
       nuts1: DK0
       nuts2: DK05
   - DKZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Denmark
       nuts1: DKZ
       nuts2: DKZZ
   - DE111:
-      name: Stuttgart, Stadtkreis
+      area_name: Stuttgart, Stadtkreis
       country: Germany
       nuts1: DE1
       nuts2: DE11
   - DE112:
-      name: Böblingen
+      area_name: Böblingen
       country: Germany
       nuts1: DE1
       nuts2: DE11
   - DE113:
-      name: Esslingen
+      area_name: Esslingen
       country: Germany
       nuts1: DE1
       nuts2: DE11
   - DE114:
-      name: Göppingen
+      area_name: Göppingen
       country: Germany
       nuts1: DE1
       nuts2: DE11
   - DE115:
-      name: Ludwigsburg
+      area_name: Ludwigsburg
       country: Germany
       nuts1: DE1
       nuts2: DE11
   - DE116:
-      name: Rems-Murr-Kreis
+      area_name: Rems-Murr-Kreis
       country: Germany
       nuts1: DE1
       nuts2: DE11
   - DE117:
-      name: Heilbronn, Stadtkreis
+      area_name: Heilbronn, Stadtkreis
       country: Germany
       nuts1: DE1
       nuts2: DE11
   - DE118:
-      name: Heilbronn, Landkreis
+      area_name: Heilbronn, Landkreis
       country: Germany
       nuts1: DE1
       nuts2: DE11
   - DE119:
-      name: Hohenlohekreis
+      area_name: Hohenlohekreis
       country: Germany
       nuts1: DE1
       nuts2: DE11
   - DE11A:
-      name: Schwäbisch Hall
+      area_name: Schwäbisch Hall
       country: Germany
       nuts1: DE1
       nuts2: DE11
   - DE11B:
-      name: Main-Tauber-Kreis
+      area_name: Main-Tauber-Kreis
       country: Germany
       nuts1: DE1
       nuts2: DE11
   - DE11C:
-      name: Heidenheim
+      area_name: Heidenheim
       country: Germany
       nuts1: DE1
       nuts2: DE11
   - DE11D:
-      name: Ostalbkreis
+      area_name: Ostalbkreis
       country: Germany
       nuts1: DE1
       nuts2: DE11
   - DE121:
-      name: Baden-Baden, Stadtkreis
+      area_name: Baden-Baden, Stadtkreis
       country: Germany
       nuts1: DE1
       nuts2: DE12
   - DE122:
-      name: Karlsruhe, Stadtkreis
+      area_name: Karlsruhe, Stadtkreis
       country: Germany
       nuts1: DE1
       nuts2: DE12
   - DE123:
-      name: Karlsruhe, Landkreis
+      area_name: Karlsruhe, Landkreis
       country: Germany
       nuts1: DE1
       nuts2: DE12
   - DE124:
-      name: Rastatt
+      area_name: Rastatt
       country: Germany
       nuts1: DE1
       nuts2: DE12
   - DE125:
-      name: Heidelberg, Stadtkreis
+      area_name: Heidelberg, Stadtkreis
       country: Germany
       nuts1: DE1
       nuts2: DE12
   - DE126:
-      name: Mannheim, Stadtkreis
+      area_name: Mannheim, Stadtkreis
       country: Germany
       nuts1: DE1
       nuts2: DE12
   - DE127:
-      name: Neckar-Odenwald-Kreis
+      area_name: Neckar-Odenwald-Kreis
       country: Germany
       nuts1: DE1
       nuts2: DE12
   - DE128:
-      name: Rhein-Neckar-Kreis
+      area_name: Rhein-Neckar-Kreis
       country: Germany
       nuts1: DE1
       nuts2: DE12
   - DE129:
-      name: Pforzheim, Stadtkreis
+      area_name: Pforzheim, Stadtkreis
       country: Germany
       nuts1: DE1
       nuts2: DE12
   - DE12A:
-      name: Calw
+      area_name: Calw
       country: Germany
       nuts1: DE1
       nuts2: DE12
   - DE12B:
-      name: Enzkreis
+      area_name: Enzkreis
       country: Germany
       nuts1: DE1
       nuts2: DE12
   - DE12C:
-      name: Freudenstadt
+      area_name: Freudenstadt
       country: Germany
       nuts1: DE1
       nuts2: DE12
   - DE131:
-      name: Freiburg im Breisgau, Stadtkreis
+      area_name: Freiburg im Breisgau, Stadtkreis
       country: Germany
       nuts1: DE1
       nuts2: DE13
   - DE132:
-      name: Breisgau-Hochschwarzwald
+      area_name: Breisgau-Hochschwarzwald
       country: Germany
       nuts1: DE1
       nuts2: DE13
   - DE133:
-      name: Emmendingen
+      area_name: Emmendingen
       country: Germany
       nuts1: DE1
       nuts2: DE13
   - DE134:
-      name: Ortenaukreis
+      area_name: Ortenaukreis
       country: Germany
       nuts1: DE1
       nuts2: DE13
   - DE135:
-      name: Rottweil
+      area_name: Rottweil
       country: Germany
       nuts1: DE1
       nuts2: DE13
   - DE136:
-      name: Schwarzwald-Baar-Kreis
+      area_name: Schwarzwald-Baar-Kreis
       country: Germany
       nuts1: DE1
       nuts2: DE13
   - DE137:
-      name: Tuttlingen
+      area_name: Tuttlingen
       country: Germany
       nuts1: DE1
       nuts2: DE13
   - DE138:
-      name: Konstanz
+      area_name: Konstanz
       country: Germany
       nuts1: DE1
       nuts2: DE13
   - DE139:
-      name: Lörrach
+      area_name: Lörrach
       country: Germany
       nuts1: DE1
       nuts2: DE13
   - DE13A:
-      name: Waldshut
+      area_name: Waldshut
       country: Germany
       nuts1: DE1
       nuts2: DE13
   - DE141:
-      name: Reutlingen
+      area_name: Reutlingen
       country: Germany
       nuts1: DE1
       nuts2: DE14
   - DE142:
-      name: Tübingen, Landkreis
+      area_name: Tübingen, Landkreis
       country: Germany
       nuts1: DE1
       nuts2: DE14
   - DE143:
-      name: Zollernalbkreis
+      area_name: Zollernalbkreis
       country: Germany
       nuts1: DE1
       nuts2: DE14
   - DE144:
-      name: Ulm, Stadtkreis
+      area_name: Ulm, Stadtkreis
       country: Germany
       nuts1: DE1
       nuts2: DE14
   - DE145:
-      name: Alb-Donau-Kreis
+      area_name: Alb-Donau-Kreis
       country: Germany
       nuts1: DE1
       nuts2: DE14
   - DE146:
-      name: Biberach
+      area_name: Biberach
       country: Germany
       nuts1: DE1
       nuts2: DE14
   - DE147:
-      name: Bodenseekreis
+      area_name: Bodenseekreis
       country: Germany
       nuts1: DE1
       nuts2: DE14
   - DE148:
-      name: Ravensburg
+      area_name: Ravensburg
       country: Germany
       nuts1: DE1
       nuts2: DE14
   - DE149:
-      name: Sigmaringen
+      area_name: Sigmaringen
       country: Germany
       nuts1: DE1
       nuts2: DE14
   - DE211:
-      name: Ingolstadt, Kreisfreie Stadt
+      area_name: Ingolstadt, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE212:
-      name: München, Kreisfreie Stadt
+      area_name: München, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE213:
-      name: Rosenheim, Kreisfreie Stadt
+      area_name: Rosenheim, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE214:
-      name: Altötting
+      area_name: Altötting
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE215:
-      name: Berchtesgadener Land
+      area_name: Berchtesgadener Land
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE216:
-      name: Bad Tölz-Wolfratshausen
+      area_name: Bad Tölz-Wolfratshausen
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE217:
-      name: Dachau
+      area_name: Dachau
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE218:
-      name: Ebersberg
+      area_name: Ebersberg
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE219:
-      name: Eichstätt
+      area_name: Eichstätt
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE21A:
-      name: Erding
+      area_name: Erding
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE21B:
-      name: Freising
+      area_name: Freising
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE21C:
-      name: Fürstenfeldbruck
+      area_name: Fürstenfeldbruck
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE21D:
-      name: Garmisch-Partenkirchen
+      area_name: Garmisch-Partenkirchen
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE21E:
-      name: Landsberg am Lech
+      area_name: Landsberg am Lech
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE21F:
-      name: Miesbach
+      area_name: Miesbach
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE21G:
-      name: Mühldorf a. Inn
+      area_name: Mühldorf a. Inn
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE21H:
-      name: München, Landkreis
+      area_name: München, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE21I:
-      name: Neuburg-Schrobenhausen
+      area_name: Neuburg-Schrobenhausen
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE21J:
-      name: Pfaffenhofen a. d. Ilm
+      area_name: Pfaffenhofen a. d. Ilm
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE21K:
-      name: Rosenheim, Landkreis
+      area_name: Rosenheim, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE21L:
-      name: Starnberg
+      area_name: Starnberg
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE21M:
-      name: Traunstein
+      area_name: Traunstein
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE21N:
-      name: Weilheim-Schongau
+      area_name: Weilheim-Schongau
       country: Germany
       nuts1: DE2
       nuts2: DE21
   - DE221:
-      name: Landshut, Kreisfreie Stadt
+      area_name: Landshut, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE22
   - DE222:
-      name: Passau, Kreisfreie Stadt
+      area_name: Passau, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE22
   - DE223:
-      name: Straubing, Kreisfreie Stadt
+      area_name: Straubing, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE22
   - DE224:
-      name: Deggendorf
+      area_name: Deggendorf
       country: Germany
       nuts1: DE2
       nuts2: DE22
   - DE225:
-      name: Freyung-Grafenau
+      area_name: Freyung-Grafenau
       country: Germany
       nuts1: DE2
       nuts2: DE22
   - DE226:
-      name: Kelheim
+      area_name: Kelheim
       country: Germany
       nuts1: DE2
       nuts2: DE22
   - DE227:
-      name: Landshut, Landkreis
+      area_name: Landshut, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE22
   - DE228:
-      name: Passau, Landkreis
+      area_name: Passau, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE22
   - DE229:
-      name: Regen
+      area_name: Regen
       country: Germany
       nuts1: DE2
       nuts2: DE22
   - DE22A:
-      name: Rottal-Inn
+      area_name: Rottal-Inn
       country: Germany
       nuts1: DE2
       nuts2: DE22
   - DE22B:
-      name: Straubing-Bogen
+      area_name: Straubing-Bogen
       country: Germany
       nuts1: DE2
       nuts2: DE22
   - DE22C:
-      name: Dingolfing-Landau
+      area_name: Dingolfing-Landau
       country: Germany
       nuts1: DE2
       nuts2: DE22
   - DE231:
-      name: Amberg, Kreisfreie Stadt
+      area_name: Amberg, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE23
   - DE232:
-      name: Regensburg, Kreisfreie Stadt
+      area_name: Regensburg, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE23
   - DE233:
-      name: Weiden i. d. Opf, Kreisfreie Stadt
+      area_name: Weiden i. d. Opf, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE23
   - DE234:
-      name: Amberg-Sulzbach
+      area_name: Amberg-Sulzbach
       country: Germany
       nuts1: DE2
       nuts2: DE23
   - DE235:
-      name: Cham
+      area_name: Cham
       country: Germany
       nuts1: DE2
       nuts2: DE23
   - DE236:
-      name: Neumarkt i. d. OPf.
+      area_name: Neumarkt i. d. OPf.
       country: Germany
       nuts1: DE2
       nuts2: DE23
   - DE237:
-      name: Neustadt a. d. Waldnaab
+      area_name: Neustadt a. d. Waldnaab
       country: Germany
       nuts1: DE2
       nuts2: DE23
   - DE238:
-      name: Regensburg, Landkreis
+      area_name: Regensburg, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE23
   - DE239:
-      name: Schwandorf
+      area_name: Schwandorf
       country: Germany
       nuts1: DE2
       nuts2: DE23
   - DE23A:
-      name: Tirschenreuth
+      area_name: Tirschenreuth
       country: Germany
       nuts1: DE2
       nuts2: DE23
   - DE241:
-      name: Bamberg, Kreisfreie Stadt
+      area_name: Bamberg, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE24
   - DE242:
-      name: Bayreuth, Kreisfreie Stadt
+      area_name: Bayreuth, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE24
   - DE243:
-      name: Coburg, Kreisfreie Stadt
+      area_name: Coburg, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE24
   - DE244:
-      name: Hof, Kreisfreie Stadt
+      area_name: Hof, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE24
   - DE245:
-      name: Bamberg, Landkreis
+      area_name: Bamberg, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE24
   - DE246:
-      name: Bayreuth, Landkreis
+      area_name: Bayreuth, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE24
   - DE247:
-      name: Coburg, Landkreis
+      area_name: Coburg, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE24
   - DE248:
-      name: Forchheim
+      area_name: Forchheim
       country: Germany
       nuts1: DE2
       nuts2: DE24
   - DE249:
-      name: Hof, Landkreis
+      area_name: Hof, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE24
   - DE24A:
-      name: Kronach
+      area_name: Kronach
       country: Germany
       nuts1: DE2
       nuts2: DE24
   - DE24B:
-      name: Kulmbach
+      area_name: Kulmbach
       country: Germany
       nuts1: DE2
       nuts2: DE24
   - DE24C:
-      name: Lichtenfels
+      area_name: Lichtenfels
       country: Germany
       nuts1: DE2
       nuts2: DE24
   - DE24D:
-      name: Wunsiedel i. Fichtelgebirge
+      area_name: Wunsiedel i. Fichtelgebirge
       country: Germany
       nuts1: DE2
       nuts2: DE24
   - DE251:
-      name: Ansbach, Kreisfreie Stadt
+      area_name: Ansbach, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE25
   - DE252:
-      name: Erlangen, Kreisfreie Stadt
+      area_name: Erlangen, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE25
   - DE253:
-      name: Fürth, Kreisfreie Stadt
+      area_name: Fürth, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE25
   - DE254:
-      name: Nürnberg, Kreisfreie Stadt
+      area_name: Nürnberg, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE25
   - DE255:
-      name: Schwabach, Kreisfreie Stadt
+      area_name: Schwabach, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE25
   - DE256:
-      name: Ansbach, Landkreis
+      area_name: Ansbach, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE25
   - DE257:
-      name: Erlangen-Höchstadt
+      area_name: Erlangen-Höchstadt
       country: Germany
       nuts1: DE2
       nuts2: DE25
   - DE258:
-      name: Fürth, Landkreis
+      area_name: Fürth, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE25
   - DE259:
-      name: Nürnberger Land
+      area_name: Nürnberger Land
       country: Germany
       nuts1: DE2
       nuts2: DE25
   - DE25A:
-      name: Neustadt a. d. Aisch-Bad Windsheim
+      area_name: Neustadt a. d. Aisch-Bad Windsheim
       country: Germany
       nuts1: DE2
       nuts2: DE25
   - DE25B:
-      name: Roth
+      area_name: Roth
       country: Germany
       nuts1: DE2
       nuts2: DE25
   - DE25C:
-      name: Weißenburg-Gunzenhausen
+      area_name: Weißenburg-Gunzenhausen
       country: Germany
       nuts1: DE2
       nuts2: DE25
   - DE261:
-      name: Aschaffenburg, Kreisfreie Stadt
+      area_name: Aschaffenburg, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE26
   - DE262:
-      name: Schweinfurt, Kreisfreie Stadt
+      area_name: Schweinfurt, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE26
   - DE263:
-      name: Würzburg, Kreisfreie Stadt
+      area_name: Würzburg, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE26
   - DE264:
-      name: Aschaffenburg, Landkreis
+      area_name: Aschaffenburg, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE26
   - DE265:
-      name: Bad Kissingen
+      area_name: Bad Kissingen
       country: Germany
       nuts1: DE2
       nuts2: DE26
   - DE266:
-      name: Rhön-Grabfeld
+      area_name: Rhön-Grabfeld
       country: Germany
       nuts1: DE2
       nuts2: DE26
   - DE267:
-      name: Haßberge
+      area_name: Haßberge
       country: Germany
       nuts1: DE2
       nuts2: DE26
   - DE268:
-      name: Kitzingen
+      area_name: Kitzingen
       country: Germany
       nuts1: DE2
       nuts2: DE26
   - DE269:
-      name: Miltenberg
+      area_name: Miltenberg
       country: Germany
       nuts1: DE2
       nuts2: DE26
   - DE26A:
-      name: Main-Spessart
+      area_name: Main-Spessart
       country: Germany
       nuts1: DE2
       nuts2: DE26
   - DE26B:
-      name: Schweinfurt, Landkreis
+      area_name: Schweinfurt, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE26
   - DE26C:
-      name: Würzburg, Landkreis
+      area_name: Würzburg, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE26
   - DE271:
-      name: Augsburg, Kreisfreie Stadt
+      area_name: Augsburg, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE27
   - DE272:
-      name: Kaufbeuren, Kreisfreie Stadt
+      area_name: Kaufbeuren, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE27
   - DE273:
-      name: Kempten (Allgäu), Kreisfreie Stadt
+      area_name: Kempten (Allgäu), Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE27
   - DE274:
-      name: Memmingen, Kreisfreie Stadt
+      area_name: Memmingen, Kreisfreie Stadt
       country: Germany
       nuts1: DE2
       nuts2: DE27
   - DE275:
-      name: Aichach-Friedberg
+      area_name: Aichach-Friedberg
       country: Germany
       nuts1: DE2
       nuts2: DE27
   - DE276:
-      name: Augsburg, Landkreis
+      area_name: Augsburg, Landkreis
       country: Germany
       nuts1: DE2
       nuts2: DE27
   - DE277:
-      name: Dillingen a.d. Donau
+      area_name: Dillingen a.d. Donau
       country: Germany
       nuts1: DE2
       nuts2: DE27
   - DE278:
-      name: Günzburg
+      area_name: Günzburg
       country: Germany
       nuts1: DE2
       nuts2: DE27
   - DE279:
-      name: Neu-Ulm
+      area_name: Neu-Ulm
       country: Germany
       nuts1: DE2
       nuts2: DE27
   - DE27A:
-      name: Lindau (Bodensee)
+      area_name: Lindau (Bodensee)
       country: Germany
       nuts1: DE2
       nuts2: DE27
   - DE27B:
-      name: Ostallgäu
+      area_name: Ostallgäu
       country: Germany
       nuts1: DE2
       nuts2: DE27
   - DE27C:
-      name: Unterallgäu
+      area_name: Unterallgäu
       country: Germany
       nuts1: DE2
       nuts2: DE27
   - DE27D:
-      name: Donau-Ries
+      area_name: Donau-Ries
       country: Germany
       nuts1: DE2
       nuts2: DE27
   - DE27E:
-      name: Oberallgäu
+      area_name: Oberallgäu
       country: Germany
       nuts1: DE2
       nuts2: DE27
   - DE300:
-      name: Berlin
+      area_name: Berlin
       country: Germany
       nuts1: DE3
       nuts2: DE30
   - DE401:
-      name: Brandenburg an der Havel, Kreisfreie Stadt
+      area_name: Brandenburg an der Havel, Kreisfreie Stadt
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE402:
-      name: Cottbus, Kreisfreie Stadt
+      area_name: Cottbus, Kreisfreie Stadt
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE403:
-      name: Frankfurt (Oder), Kreisfreie Stadt
+      area_name: Frankfurt (Oder), Kreisfreie Stadt
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE404:
-      name: Potsdam, Kreisfreie Stadt
+      area_name: Potsdam, Kreisfreie Stadt
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE405:
-      name: Barnim
+      area_name: Barnim
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE406:
-      name: Dahme-Spreewald
+      area_name: Dahme-Spreewald
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE407:
-      name: Elbe-Elster
+      area_name: Elbe-Elster
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE408:
-      name: Havelland
+      area_name: Havelland
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE409:
-      name: Märkisch-Oderland
+      area_name: Märkisch-Oderland
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE40A:
-      name: Oberhavel
+      area_name: Oberhavel
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE40B:
-      name: Oberspreewald-Lausitz
+      area_name: Oberspreewald-Lausitz
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE40C:
-      name: Oder-Spree
+      area_name: Oder-Spree
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE40D:
-      name: Ostprignitz-Ruppin
+      area_name: Ostprignitz-Ruppin
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE40E:
-      name: Potsdam-Mittelmark
+      area_name: Potsdam-Mittelmark
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE40F:
-      name: Prignitz
+      area_name: Prignitz
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE40G:
-      name: Spree-Neiße
+      area_name: Spree-Neiße
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE40H:
-      name: Teltow-Fläming
+      area_name: Teltow-Fläming
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE40I:
-      name: Uckermark
+      area_name: Uckermark
       country: Germany
       nuts1: DE4
       nuts2: DE40
   - DE501:
-      name: Bremen, Kreisfreie Stadt
+      area_name: Bremen, Kreisfreie Stadt
       country: Germany
       nuts1: DE5
       nuts2: DE50
   - DE502:
-      name: Bremerhaven, Kreisfreie Stadt
+      area_name: Bremerhaven, Kreisfreie Stadt
       country: Germany
       nuts1: DE5
       nuts2: DE50
   - DE600:
-      name: Hamburg
+      area_name: Hamburg
       country: Germany
       nuts1: DE6
       nuts2: DE60
   - DE711:
-      name: Darmstadt, Kreisfreie Stadt
+      area_name: Darmstadt, Kreisfreie Stadt
       country: Germany
       nuts1: DE7
       nuts2: DE71
   - DE712:
-      name: Frankfurt am Main, Kreisfreie Stadt
+      area_name: Frankfurt am Main, Kreisfreie Stadt
       country: Germany
       nuts1: DE7
       nuts2: DE71
   - DE713:
-      name: Offenbach am Main, Kreisfreie Stadt
+      area_name: Offenbach am Main, Kreisfreie Stadt
       country: Germany
       nuts1: DE7
       nuts2: DE71
   - DE714:
-      name: Wiesbaden, Kreisfreie Stadt
+      area_name: Wiesbaden, Kreisfreie Stadt
       country: Germany
       nuts1: DE7
       nuts2: DE71
   - DE715:
-      name: Bergstraße
+      area_name: Bergstraße
       country: Germany
       nuts1: DE7
       nuts2: DE71
   - DE716:
-      name: Darmstadt-Dieburg
+      area_name: Darmstadt-Dieburg
       country: Germany
       nuts1: DE7
       nuts2: DE71
   - DE717:
-      name: Groß-Gerau
+      area_name: Groß-Gerau
       country: Germany
       nuts1: DE7
       nuts2: DE71
   - DE718:
-      name: Hochtaunuskreis
+      area_name: Hochtaunuskreis
       country: Germany
       nuts1: DE7
       nuts2: DE71
   - DE719:
-      name: Main-Kinzig-Kreis
+      area_name: Main-Kinzig-Kreis
       country: Germany
       nuts1: DE7
       nuts2: DE71
   - DE71A:
-      name: Main-Taunus-Kreis
+      area_name: Main-Taunus-Kreis
       country: Germany
       nuts1: DE7
       nuts2: DE71
   - DE71B:
-      name: Odenwaldkreis
+      area_name: Odenwaldkreis
       country: Germany
       nuts1: DE7
       nuts2: DE71
   - DE71C:
-      name: Offenbach, Landkreis
+      area_name: Offenbach, Landkreis
       country: Germany
       nuts1: DE7
       nuts2: DE71
   - DE71D:
-      name: Rheingau-Taunus-Kreis
+      area_name: Rheingau-Taunus-Kreis
       country: Germany
       nuts1: DE7
       nuts2: DE71
   - DE71E:
-      name: Wetteraukreis
+      area_name: Wetteraukreis
       country: Germany
       nuts1: DE7
       nuts2: DE71
   - DE721:
-      name: Gießen, Landkreis
+      area_name: Gießen, Landkreis
       country: Germany
       nuts1: DE7
       nuts2: DE72
   - DE722:
-      name: Lahn-Dill-Kreis
+      area_name: Lahn-Dill-Kreis
       country: Germany
       nuts1: DE7
       nuts2: DE72
   - DE723:
-      name: Limburg-Weilburg
+      area_name: Limburg-Weilburg
       country: Germany
       nuts1: DE7
       nuts2: DE72
   - DE724:
-      name: Marburg-Biedenkopf
+      area_name: Marburg-Biedenkopf
       country: Germany
       nuts1: DE7
       nuts2: DE72
   - DE725:
-      name: Vogelsbergkreis
+      area_name: Vogelsbergkreis
       country: Germany
       nuts1: DE7
       nuts2: DE72
   - DE731:
-      name: Kassel, Kreisfreie Stadt
+      area_name: Kassel, Kreisfreie Stadt
       country: Germany
       nuts1: DE7
       nuts2: DE73
   - DE732:
-      name: Fulda
+      area_name: Fulda
       country: Germany
       nuts1: DE7
       nuts2: DE73
   - DE733:
-      name: Hersfeld-Rotenburg
+      area_name: Hersfeld-Rotenburg
       country: Germany
       nuts1: DE7
       nuts2: DE73
   - DE734:
-      name: Kassel, Landkreis
+      area_name: Kassel, Landkreis
       country: Germany
       nuts1: DE7
       nuts2: DE73
   - DE735:
-      name: Schwalm-Eder-Kreis
+      area_name: Schwalm-Eder-Kreis
       country: Germany
       nuts1: DE7
       nuts2: DE73
   - DE736:
-      name: Waldeck-Frankenberg
+      area_name: Waldeck-Frankenberg
       country: Germany
       nuts1: DE7
       nuts2: DE73
   - DE737:
-      name: Werra-Meißner-Kreis
+      area_name: Werra-Meißner-Kreis
       country: Germany
       nuts1: DE7
       nuts2: DE73
   - DE803:
-      name: Rostock, Kreisfreie Stadt
+      area_name: Rostock, Kreisfreie Stadt
       country: Germany
       nuts1: DE8
       nuts2: DE80
   - DE804:
-      name: Schwerin, Kreisfreie Stadt
+      area_name: Schwerin, Kreisfreie Stadt
       country: Germany
       nuts1: DE8
       nuts2: DE80
   - DE80J:
-      name: Mecklenburgische Seenplatte
+      area_name: Mecklenburgische Seenplatte
       country: Germany
       nuts1: DE8
       nuts2: DE80
   - DE80K:
-      name: Landkreis Rostock
+      area_name: Landkreis Rostock
       country: Germany
       nuts1: DE8
       nuts2: DE80
   - DE80L:
-      name: Vorpommern-Rügen
+      area_name: Vorpommern-Rügen
       country: Germany
       nuts1: DE8
       nuts2: DE80
   - DE80M:
-      name: Nordwestmecklenburg
+      area_name: Nordwestmecklenburg
       country: Germany
       nuts1: DE8
       nuts2: DE80
   - DE80N:
-      name: Vorpommern-Greifswald
+      area_name: Vorpommern-Greifswald
       country: Germany
       nuts1: DE8
       nuts2: DE80
   - DE80O:
-      name: Ludwigslust-Parchim
+      area_name: Ludwigslust-Parchim
       country: Germany
       nuts1: DE8
       nuts2: DE80
   - DE911:
-      name: Braunschweig, Kreisfreie Stadt
+      area_name: Braunschweig, Kreisfreie Stadt
       country: Germany
       nuts1: DE9
       nuts2: DE91
   - DE912:
-      name: Salzgitter, Kreisfreie Stadt
+      area_name: Salzgitter, Kreisfreie Stadt
       country: Germany
       nuts1: DE9
       nuts2: DE91
   - DE913:
-      name: Wolfsburg, Kreisfreie Stadt
+      area_name: Wolfsburg, Kreisfreie Stadt
       country: Germany
       nuts1: DE9
       nuts2: DE91
   - DE914:
-      name: Gifhorn
+      area_name: Gifhorn
       country: Germany
       nuts1: DE9
       nuts2: DE91
   - DE916:
-      name: Goslar
+      area_name: Goslar
       country: Germany
       nuts1: DE9
       nuts2: DE91
   - DE917:
-      name: Helmstedt
+      area_name: Helmstedt
       country: Germany
       nuts1: DE9
       nuts2: DE91
   - DE918:
-      name: Northeim
+      area_name: Northeim
       country: Germany
       nuts1: DE9
       nuts2: DE91
   - DE91A:
-      name: Peine
+      area_name: Peine
       country: Germany
       nuts1: DE9
       nuts2: DE91
   - DE91B:
-      name: Wolfenbüttel
+      area_name: Wolfenbüttel
       country: Germany
       nuts1: DE9
       nuts2: DE91
   - DE91C:
-      name: Göttingen
+      area_name: Göttingen
       country: Germany
       nuts1: DE9
       nuts2: DE91
   - DE922:
-      name: Diepholz
+      area_name: Diepholz
       country: Germany
       nuts1: DE9
       nuts2: DE92
   - DE923:
-      name: Hameln-Pyrmont
+      area_name: Hameln-Pyrmont
       country: Germany
       nuts1: DE9
       nuts2: DE92
   - DE925:
-      name: Hildesheim
+      area_name: Hildesheim
       country: Germany
       nuts1: DE9
       nuts2: DE92
   - DE926:
-      name: Holzminden
+      area_name: Holzminden
       country: Germany
       nuts1: DE9
       nuts2: DE92
   - DE927:
-      name: Nienburg (Weser)
+      area_name: Nienburg (Weser)
       country: Germany
       nuts1: DE9
       nuts2: DE92
   - DE928:
-      name: Schaumburg
+      area_name: Schaumburg
       country: Germany
       nuts1: DE9
       nuts2: DE92
   - DE929:
-      name: Region Hannover
+      area_name: Region Hannover
       country: Germany
       nuts1: DE9
       nuts2: DE92
   - DE931:
-      name: Celle
+      area_name: Celle
       country: Germany
       nuts1: DE9
       nuts2: DE93
   - DE932:
-      name: Cuxhaven
+      area_name: Cuxhaven
       country: Germany
       nuts1: DE9
       nuts2: DE93
   - DE933:
-      name: Harburg
+      area_name: Harburg
       country: Germany
       nuts1: DE9
       nuts2: DE93
   - DE934:
-      name: Lüchow-Dannenberg
+      area_name: Lüchow-Dannenberg
       country: Germany
       nuts1: DE9
       nuts2: DE93
   - DE935:
-      name: Lüneburg, Landkreis
+      area_name: Lüneburg, Landkreis
       country: Germany
       nuts1: DE9
       nuts2: DE93
   - DE936:
-      name: Osterholz
+      area_name: Osterholz
       country: Germany
       nuts1: DE9
       nuts2: DE93
   - DE937:
-      name: Rotenburg (Wümme)
+      area_name: Rotenburg (Wümme)
       country: Germany
       nuts1: DE9
       nuts2: DE93
   - DE938:
-      name: Heidekreis
+      area_name: Heidekreis
       country: Germany
       nuts1: DE9
       nuts2: DE93
   - DE939:
-      name: Stade
+      area_name: Stade
       country: Germany
       nuts1: DE9
       nuts2: DE93
   - DE93A:
-      name: Uelzen
+      area_name: Uelzen
       country: Germany
       nuts1: DE9
       nuts2: DE93
   - DE93B:
-      name: Verden
+      area_name: Verden
       country: Germany
       nuts1: DE9
       nuts2: DE93
   - DE941:
-      name: Delmenhorst, Kreisfreie Stadt
+      area_name: Delmenhorst, Kreisfreie Stadt
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE942:
-      name: Emden, Kreisfreie Stadt
+      area_name: Emden, Kreisfreie Stadt
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE943:
-      name: Oldenburg (Oldenburg), Kreisfreie Stadt
+      area_name: Oldenburg (Oldenburg), Kreisfreie Stadt
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE944:
-      name: Osnabrück, Kreisfreie Stadt
+      area_name: Osnabrück, Kreisfreie Stadt
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE945:
-      name: Wilhelmshaven, Kreisfreie Stadt
+      area_name: Wilhelmshaven, Kreisfreie Stadt
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE946:
-      name: Ammerland
+      area_name: Ammerland
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE947:
-      name: Aurich
+      area_name: Aurich
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE948:
-      name: Cloppenburg
+      area_name: Cloppenburg
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE949:
-      name: Emsland
+      area_name: Emsland
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE94A:
-      name: Friesland (DE)
+      area_name: Friesland (DE)
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE94B:
-      name: Grafschaft Bentheim
+      area_name: Grafschaft Bentheim
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE94C:
-      name: Leer
+      area_name: Leer
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE94D:
-      name: Oldenburg, Landkreis
+      area_name: Oldenburg, Landkreis
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE94E:
-      name: Osnabrück, Landkreis
+      area_name: Osnabrück, Landkreis
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE94F:
-      name: Vechta
+      area_name: Vechta
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE94G:
-      name: Wesermarsch
+      area_name: Wesermarsch
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DE94H:
-      name: Wittmund
+      area_name: Wittmund
       country: Germany
       nuts1: DE9
       nuts2: DE94
   - DEA11:
-      name: Düsseldorf, Kreisfreie Stadt
+      area_name: Düsseldorf, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA12:
-      name: Duisburg, Kreisfreie Stadt
+      area_name: Duisburg, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA13:
-      name: Essen, Kreisfreie Stadt
+      area_name: Essen, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA14:
-      name: Krefeld, Kreisfreie Stadt
+      area_name: Krefeld, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA15:
-      name: Mönchengladbach, Kreisfreie Stadt
+      area_name: Mönchengladbach, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA16:
-      name: Mülheim an der Ruhr, Kreisfreie Stadt
+      area_name: Mülheim an der Ruhr, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA17:
-      name: Oberhausen, Kreisfreie Stadt
+      area_name: Oberhausen, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA18:
-      name: Remscheid, Kreisfreie Stadt
+      area_name: Remscheid, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA19:
-      name: Solingen, Kreisfreie Stadt
+      area_name: Solingen, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA1A:
-      name: Wuppertal, Kreisfreie Stadt
+      area_name: Wuppertal, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA1B:
-      name: Kleve
+      area_name: Kleve
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA1C:
-      name: Mettmann
+      area_name: Mettmann
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA1D:
-      name: Rhein-Kreis Neuss
+      area_name: Rhein-Kreis Neuss
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA1E:
-      name: Viersen
+      area_name: Viersen
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA1F:
-      name: Wesel
+      area_name: Wesel
       country: Germany
       nuts1: DEA
       nuts2: DEA1
   - DEA22:
-      name: Bonn, Kreisfreie Stadt
+      area_name: Bonn, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA2
   - DEA23:
-      name: Köln, Kreisfreie Stadt
+      area_name: Köln, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA2
   - DEA24:
-      name: Leverkusen, Kreisfreie Stadt
+      area_name: Leverkusen, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA2
   - DEA26:
-      name: Düren
+      area_name: Düren
       country: Germany
       nuts1: DEA
       nuts2: DEA2
   - DEA27:
-      name: Rhein-Erft-Kreis
+      area_name: Rhein-Erft-Kreis
       country: Germany
       nuts1: DEA
       nuts2: DEA2
   - DEA28:
-      name: Euskirchen
+      area_name: Euskirchen
       country: Germany
       nuts1: DEA
       nuts2: DEA2
   - DEA29:
-      name: Heinsberg
+      area_name: Heinsberg
       country: Germany
       nuts1: DEA
       nuts2: DEA2
   - DEA2A:
-      name: Oberbergischer Kreis
+      area_name: Oberbergischer Kreis
       country: Germany
       nuts1: DEA
       nuts2: DEA2
   - DEA2B:
-      name: Rheinisch-Bergischer Kreis
+      area_name: Rheinisch-Bergischer Kreis
       country: Germany
       nuts1: DEA
       nuts2: DEA2
   - DEA2C:
-      name: Rhein-Sieg-Kreis
+      area_name: Rhein-Sieg-Kreis
       country: Germany
       nuts1: DEA
       nuts2: DEA2
   - DEA2D:
-      name: Städteregion Aachen
+      area_name: Städteregion Aachen
       country: Germany
       nuts1: DEA
       nuts2: DEA2
   - DEA31:
-      name: Bottrop, Kreisfreie Stadt
+      area_name: Bottrop, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA3
   - DEA32:
-      name: Gelsenkirchen, Kreisfreie Stadt
+      area_name: Gelsenkirchen, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA3
   - DEA33:
-      name: Münster, Kreisfreie Stadt
+      area_name: Münster, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA3
   - DEA34:
-      name: Borken
+      area_name: Borken
       country: Germany
       nuts1: DEA
       nuts2: DEA3
   - DEA35:
-      name: Coesfeld
+      area_name: Coesfeld
       country: Germany
       nuts1: DEA
       nuts2: DEA3
   - DEA36:
-      name: Recklinghausen
+      area_name: Recklinghausen
       country: Germany
       nuts1: DEA
       nuts2: DEA3
   - DEA37:
-      name: Steinfurt
+      area_name: Steinfurt
       country: Germany
       nuts1: DEA
       nuts2: DEA3
   - DEA38:
-      name: Warendorf
+      area_name: Warendorf
       country: Germany
       nuts1: DEA
       nuts2: DEA3
   - DEA41:
-      name: Bielefeld, Kreisfreie Stadt
+      area_name: Bielefeld, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA4
   - DEA42:
-      name: Gütersloh
+      area_name: Gütersloh
       country: Germany
       nuts1: DEA
       nuts2: DEA4
   - DEA43:
-      name: Herford
+      area_name: Herford
       country: Germany
       nuts1: DEA
       nuts2: DEA4
   - DEA44:
-      name: Höxter
+      area_name: Höxter
       country: Germany
       nuts1: DEA
       nuts2: DEA4
   - DEA45:
-      name: Lippe
+      area_name: Lippe
       country: Germany
       nuts1: DEA
       nuts2: DEA4
   - DEA46:
-      name: Minden-Lübbecke
+      area_name: Minden-Lübbecke
       country: Germany
       nuts1: DEA
       nuts2: DEA4
   - DEA47:
-      name: Paderborn
+      area_name: Paderborn
       country: Germany
       nuts1: DEA
       nuts2: DEA4
   - DEA51:
-      name: Bochum, Kreisfreie Stadt
+      area_name: Bochum, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA5
   - DEA52:
-      name: Dortmund, Kreisfreie Stadt
+      area_name: Dortmund, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA5
   - DEA53:
-      name: Hagen, Kreisfreie Stadt
+      area_name: Hagen, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA5
   - DEA54:
-      name: Hamm, Kreisfreie Stadt
+      area_name: Hamm, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA5
   - DEA55:
-      name: Herne, Kreisfreie Stadt
+      area_name: Herne, Kreisfreie Stadt
       country: Germany
       nuts1: DEA
       nuts2: DEA5
   - DEA56:
-      name: Ennepe-Ruhr-Kreis
+      area_name: Ennepe-Ruhr-Kreis
       country: Germany
       nuts1: DEA
       nuts2: DEA5
   - DEA57:
-      name: Hochsauerlandkreis
+      area_name: Hochsauerlandkreis
       country: Germany
       nuts1: DEA
       nuts2: DEA5
   - DEA58:
-      name: Märkischer Kreis
+      area_name: Märkischer Kreis
       country: Germany
       nuts1: DEA
       nuts2: DEA5
   - DEA59:
-      name: Olpe
+      area_name: Olpe
       country: Germany
       nuts1: DEA
       nuts2: DEA5
   - DEA5A:
-      name: Siegen-Wittgenstein
+      area_name: Siegen-Wittgenstein
       country: Germany
       nuts1: DEA
       nuts2: DEA5
   - DEA5B:
-      name: Soest
+      area_name: Soest
       country: Germany
       nuts1: DEA
       nuts2: DEA5
   - DEA5C:
-      name: Unna
+      area_name: Unna
       country: Germany
       nuts1: DEA
       nuts2: DEA5
   - DEB11:
-      name: Koblenz, Kreisfreie Stadt
+      area_name: Koblenz, Kreisfreie Stadt
       country: Germany
       nuts1: DEB
       nuts2: DEB1
   - DEB12:
-      name: Ahrweiler
+      area_name: Ahrweiler
       country: Germany
       nuts1: DEB
       nuts2: DEB1
   - DEB13:
-      name: Altenkirchen (Westerwald)
+      area_name: Altenkirchen (Westerwald)
       country: Germany
       nuts1: DEB
       nuts2: DEB1
   - DEB14:
-      name: Bad Kreuznach
+      area_name: Bad Kreuznach
       country: Germany
       nuts1: DEB
       nuts2: DEB1
   - DEB15:
-      name: Birkenfeld
+      area_name: Birkenfeld
       country: Germany
       nuts1: DEB
       nuts2: DEB1
   - DEB17:
-      name: Mayen-Koblenz
+      area_name: Mayen-Koblenz
       country: Germany
       nuts1: DEB
       nuts2: DEB1
   - DEB18:
-      name: Neuwied
+      area_name: Neuwied
       country: Germany
       nuts1: DEB
       nuts2: DEB1
   - DEB1A:
-      name: Rhein-Lahn-Kreis
+      area_name: Rhein-Lahn-Kreis
       country: Germany
       nuts1: DEB
       nuts2: DEB1
   - DEB1B:
-      name: Westerwaldkreis
+      area_name: Westerwaldkreis
       country: Germany
       nuts1: DEB
       nuts2: DEB1
   - DEB1C:
-      name: Cochem-Zell
+      area_name: Cochem-Zell
       country: Germany
       nuts1: DEB
       nuts2: DEB1
   - DEB1D:
-      name: Rhein-Hunsrück-Kreis
+      area_name: Rhein-Hunsrück-Kreis
       country: Germany
       nuts1: DEB
       nuts2: DEB1
   - DEB21:
-      name: Trier, Kreisfreie Stadt
+      area_name: Trier, Kreisfreie Stadt
       country: Germany
       nuts1: DEB
       nuts2: DEB2
   - DEB22:
-      name: Bernkastel-Wittlich
+      area_name: Bernkastel-Wittlich
       country: Germany
       nuts1: DEB
       nuts2: DEB2
   - DEB23:
-      name: Eifelkreis Bitburg-Prüm
+      area_name: Eifelkreis Bitburg-Prüm
       country: Germany
       nuts1: DEB
       nuts2: DEB2
   - DEB24:
-      name: Vulkaneifel
+      area_name: Vulkaneifel
       country: Germany
       nuts1: DEB
       nuts2: DEB2
   - DEB25:
-      name: Trier-Saarburg
+      area_name: Trier-Saarburg
       country: Germany
       nuts1: DEB
       nuts2: DEB2
   - DEB31:
-      name: Frankenthal (Pfalz), Kreisfreie Stadt
+      area_name: Frankenthal (Pfalz), Kreisfreie Stadt
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB32:
-      name: Kaiserslautern, Kreisfreie Stadt
+      area_name: Kaiserslautern, Kreisfreie Stadt
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB33:
-      name: Landau in der Pfalz, Kreisfreie Stadt
+      area_name: Landau in der Pfalz, Kreisfreie Stadt
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB34:
-      name: Ludwigshafen am Rhein, Kreisfreie Stadt
+      area_name: Ludwigshafen am Rhein, Kreisfreie Stadt
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB35:
-      name: Mainz, Kreisfreie Stadt
+      area_name: Mainz, Kreisfreie Stadt
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB36:
-      name: Neustadt an der Weinstraße, Kreisfreie Stadt
+      area_name: Neustadt an der Weinstraße, Kreisfreie Stadt
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB37:
-      name: Pirmasens, Kreisfreie Stadt
+      area_name: Pirmasens, Kreisfreie Stadt
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB38:
-      name: Speyer, Kreisfreie Stadt
+      area_name: Speyer, Kreisfreie Stadt
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB39:
-      name: Worms, Kreisfreie Stadt
+      area_name: Worms, Kreisfreie Stadt
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB3A:
-      name: Zweibrücken, Kreisfreie Stadt
+      area_name: Zweibrücken, Kreisfreie Stadt
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB3B:
-      name: Alzey-Worms
+      area_name: Alzey-Worms
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB3C:
-      name: Bad Dürkheim
+      area_name: Bad Dürkheim
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB3D:
-      name: Donnersbergkreis
+      area_name: Donnersbergkreis
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB3E:
-      name: Germersheim
+      area_name: Germersheim
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB3F:
-      name: Kaiserslautern, Landkreis
+      area_name: Kaiserslautern, Landkreis
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB3G:
-      name: Kusel
+      area_name: Kusel
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB3H:
-      name: Südliche Weinstraße
+      area_name: Südliche Weinstraße
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB3I:
-      name: Rhein-Pfalz-Kreis
+      area_name: Rhein-Pfalz-Kreis
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB3J:
-      name: Mainz-Bingen
+      area_name: Mainz-Bingen
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEB3K:
-      name: Südwestpfalz
+      area_name: Südwestpfalz
       country: Germany
       nuts1: DEB
       nuts2: DEB3
   - DEC01:
-      name: Regionalverband Saarbrücken
+      area_name: Regionalverband Saarbrücken
       country: Germany
       nuts1: DEC
       nuts2: DEC0
   - DEC02:
-      name: Merzig-Wadern
+      area_name: Merzig-Wadern
       country: Germany
       nuts1: DEC
       nuts2: DEC0
   - DEC03:
-      name: Neunkirchen
+      area_name: Neunkirchen
       country: Germany
       nuts1: DEC
       nuts2: DEC0
   - DEC04:
-      name: Saarlouis
+      area_name: Saarlouis
       country: Germany
       nuts1: DEC
       nuts2: DEC0
   - DEC05:
-      name: Saarpfalz-Kreis
+      area_name: Saarpfalz-Kreis
       country: Germany
       nuts1: DEC
       nuts2: DEC0
   - DEC06:
-      name: St. Wendel
+      area_name: St. Wendel
       country: Germany
       nuts1: DEC
       nuts2: DEC0
   - DED21:
-      name: Dresden, Kreisfreie Stadt
+      area_name: Dresden, Kreisfreie Stadt
       country: Germany
       nuts1: DED
       nuts2: DED2
   - DED2C:
-      name: Bautzen
+      area_name: Bautzen
       country: Germany
       nuts1: DED
       nuts2: DED2
   - DED2D:
-      name: Görlitz
+      area_name: Görlitz
       country: Germany
       nuts1: DED
       nuts2: DED2
   - DED2E:
-      name: Meißen
+      area_name: Meißen
       country: Germany
       nuts1: DED
       nuts2: DED2
   - DED2F:
-      name: Sächsische Schweiz-Osterzgebirge
+      area_name: Sächsische Schweiz-Osterzgebirge
       country: Germany
       nuts1: DED
       nuts2: DED2
   - DED41:
-      name: Chemnitz, Kreisfreie Stadt
+      area_name: Chemnitz, Kreisfreie Stadt
       country: Germany
       nuts1: DED
       nuts2: DED4
   - DED42:
-      name: Erzgebirgskreis
+      area_name: Erzgebirgskreis
       country: Germany
       nuts1: DED
       nuts2: DED4
   - DED43:
-      name: Mittelsachsen
+      area_name: Mittelsachsen
       country: Germany
       nuts1: DED
       nuts2: DED4
   - DED44:
-      name: Vogtlandkreis
+      area_name: Vogtlandkreis
       country: Germany
       nuts1: DED
       nuts2: DED4
   - DED45:
-      name: Zwickau
+      area_name: Zwickau
       country: Germany
       nuts1: DED
       nuts2: DED4
   - DED51:
-      name: Leipzig, Kreisfreie Stadt
+      area_name: Leipzig, Kreisfreie Stadt
       country: Germany
       nuts1: DED
       nuts2: DED5
   - DED52:
-      name: Leipzig
+      area_name: Leipzig
       country: Germany
       nuts1: DED
       nuts2: DED5
   - DED53:
-      name: Nordsachsen
+      area_name: Nordsachsen
       country: Germany
       nuts1: DED
       nuts2: DED5
   - DEE01:
-      name: Dessau-Roßlau, Kreisfreie Stadt
+      area_name: Dessau-Roßlau, Kreisfreie Stadt
       country: Germany
       nuts1: DEE
       nuts2: DEE0
   - DEE02:
-      name: Halle (Saale), Kreisfreie Stadt
+      area_name: Halle (Saale), Kreisfreie Stadt
       country: Germany
       nuts1: DEE
       nuts2: DEE0
   - DEE03:
-      name: Magdeburg, Kreisfreie Stadt
+      area_name: Magdeburg, Kreisfreie Stadt
       country: Germany
       nuts1: DEE
       nuts2: DEE0
   - DEE04:
-      name: Altmarkkreis Salzwedel
+      area_name: Altmarkkreis Salzwedel
       country: Germany
       nuts1: DEE
       nuts2: DEE0
   - DEE05:
-      name: Anhalt-Bitterfeld
+      area_name: Anhalt-Bitterfeld
       country: Germany
       nuts1: DEE
       nuts2: DEE0
   - DEE06:
-      name: Jerichower Land
+      area_name: Jerichower Land
       country: Germany
       nuts1: DEE
       nuts2: DEE0
   - DEE07:
-      name: Börde
+      area_name: Börde
       country: Germany
       nuts1: DEE
       nuts2: DEE0
   - DEE08:
-      name: Burgenlandkreis
+      area_name: Burgenlandkreis
       country: Germany
       nuts1: DEE
       nuts2: DEE0
   - DEE09:
-      name: Harz
+      area_name: Harz
       country: Germany
       nuts1: DEE
       nuts2: DEE0
   - DEE0A:
-      name: Mansfeld-Südharz
+      area_name: Mansfeld-Südharz
       country: Germany
       nuts1: DEE
       nuts2: DEE0
   - DEE0B:
-      name: Saalekreis
+      area_name: Saalekreis
       country: Germany
       nuts1: DEE
       nuts2: DEE0
   - DEE0C:
-      name: Salzlandkreis
+      area_name: Salzlandkreis
       country: Germany
       nuts1: DEE
       nuts2: DEE0
   - DEE0D:
-      name: Stendal
+      area_name: Stendal
       country: Germany
       nuts1: DEE
       nuts2: DEE0
   - DEE0E:
-      name: Wittenberg
+      area_name: Wittenberg
       country: Germany
       nuts1: DEE
       nuts2: DEE0
   - DEF01:
-      name: Flensburg, Kreisfreie Stadt
+      area_name: Flensburg, Kreisfreie Stadt
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEF02:
-      name: Kiel, Kreisfreie Stadt
+      area_name: Kiel, Kreisfreie Stadt
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEF03:
-      name: Lübeck, Kreisfreie Stadt
+      area_name: Lübeck, Kreisfreie Stadt
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEF04:
-      name: Neumünster, Kreisfreie Stadt
+      area_name: Neumünster, Kreisfreie Stadt
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEF05:
-      name: Dithmarschen
+      area_name: Dithmarschen
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEF06:
-      name: Herzogtum Lauenburg
+      area_name: Herzogtum Lauenburg
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEF07:
-      name: Nordfriesland
+      area_name: Nordfriesland
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEF08:
-      name: Ostholstein
+      area_name: Ostholstein
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEF09:
-      name: Pinneberg
+      area_name: Pinneberg
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEF0A:
-      name: Plön
+      area_name: Plön
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEF0B:
-      name: Rendsburg-Eckernförde
+      area_name: Rendsburg-Eckernförde
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEF0C:
-      name: Schleswig-Flensburg
+      area_name: Schleswig-Flensburg
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEF0D:
-      name: Segeberg
+      area_name: Segeberg
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEF0E:
-      name: Steinburg
+      area_name: Steinburg
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEF0F:
-      name: Stormarn
+      area_name: Stormarn
       country: Germany
       nuts1: DEF
       nuts2: DEF0
   - DEG01:
-      name: Erfurt, Kreisfreie Stadt
+      area_name: Erfurt, Kreisfreie Stadt
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG02:
-      name: Gera, Kreisfreie Stadt
+      area_name: Gera, Kreisfreie Stadt
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG03:
-      name: Jena, Kreisfreie Stadt
+      area_name: Jena, Kreisfreie Stadt
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG04:
-      name: Suhl, Kreisfreie Stadt
+      area_name: Suhl, Kreisfreie Stadt
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG05:
-      name: Weimar, Kreisfreie Stadt
+      area_name: Weimar, Kreisfreie Stadt
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG06:
-      name: Eichsfeld
+      area_name: Eichsfeld
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG07:
-      name: Nordhausen
+      area_name: Nordhausen
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG09:
-      name: Unstrut-Hainich-Kreis
+      area_name: Unstrut-Hainich-Kreis
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0A:
-      name: Kyffhäuserkreis
+      area_name: Kyffhäuserkreis
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0B:
-      name: Schmalkalden-Meiningen
+      area_name: Schmalkalden-Meiningen
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0C:
-      name: Gotha
+      area_name: Gotha
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0D:
-      name: Sömmerda
+      area_name: Sömmerda
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0E:
-      name: Hildburghausen
+      area_name: Hildburghausen
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0F:
-      name: Ilm-Kreis
+      area_name: Ilm-Kreis
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0G:
-      name: Weimarer Land
+      area_name: Weimarer Land
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0H:
-      name: Sonneberg
+      area_name: Sonneberg
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0I:
-      name: Saalfeld-Rudolstadt
+      area_name: Saalfeld-Rudolstadt
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0J:
-      name: Saale-Holzland-Kreis
+      area_name: Saale-Holzland-Kreis
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0K:
-      name: Saale-Orla-Kreis
+      area_name: Saale-Orla-Kreis
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0L:
-      name: Greiz
+      area_name: Greiz
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0M:
-      name: Altenburger Land
+      area_name: Altenburger Land
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0N:
-      name: Eisenach, Kreisfreie Stadt
+      area_name: Eisenach, Kreisfreie Stadt
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEG0P:
-      name: Wartburgkreis
+      area_name: Wartburgkreis
       country: Germany
       nuts1: DEG
       nuts2: DEG0
   - DEZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Germany
       nuts1: DEZ
       nuts2: DEZZ
   - EE001:
-      name: Põhja-Eesti
+      area_name: Põhja-Eesti
       country: Estonia
       nuts1: EE0
       nuts2: EE00
   - EE004:
-      name: Lääne-Eesti
+      area_name: Lääne-Eesti
       country: Estonia
       nuts1: EE0
       nuts2: EE00
   - EE008:
-      name: Lõuna-Eesti
+      area_name: Lõuna-Eesti
       country: Estonia
       nuts1: EE0
       nuts2: EE00
   - EE009:
-      name: Kesk-Eesti
+      area_name: Kesk-Eesti
       country: Estonia
       nuts1: EE0
       nuts2: EE00
   - EE00A:
-      name: Kirde-Eesti
+      area_name: Kirde-Eesti
       country: Estonia
       nuts1: EE0
       nuts2: EE00
   - EEZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Estonia
       nuts1: EEZ
       nuts2: EEZZ
   - IE041:
-      name: Border
+      area_name: Border
       country: Ireland
       nuts1: IE0
       nuts2: IE04
   - IE042:
-      name: West
+      area_name: West
       country: Ireland
       nuts1: IE0
       nuts2: IE04
   - IE051:
-      name: Mid-West 
+      area_name: Mid-West 
       country: Ireland
       nuts1: IE0
       nuts2: IE05
   - IE052:
-      name: South-East 
+      area_name: South-East 
       country: Ireland
       nuts1: IE0
       nuts2: IE05
   - IE053:
-      name: South-West 
+      area_name: South-West 
       country: Ireland
       nuts1: IE0
       nuts2: IE05
   - IE061:
-      name: Dublin
+      area_name: Dublin
       country: Ireland
       nuts1: IE0
       nuts2: IE06
   - IE062:
-      name: Mid-East
+      area_name: Mid-East
       country: Ireland
       nuts1: IE0
       nuts2: IE06
   - IE063:
-      name: Midland
+      area_name: Midland
       country: Ireland
       nuts1: IE0
       nuts2: IE06
   - IEZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Ireland
       nuts1: IEZ
       nuts2: IEZZ
   - EL301:
-      name: Βόρειος Τομέας Αθηνών
+      area_name: Βόρειος Τομέας Αθηνών
       country: Greece
       nuts1: EL3
       nuts2: EL30
   - EL302:
-      name: Δυτικός Τομέας Αθηνών
+      area_name: Δυτικός Τομέας Αθηνών
       country: Greece
       nuts1: EL3
       nuts2: EL30
   - EL303:
-      name: Κεντρικός Τομέας Αθηνών
+      area_name: Κεντρικός Τομέας Αθηνών
       country: Greece
       nuts1: EL3
       nuts2: EL30
   - EL304:
-      name: Νότιος Τομέας Αθηνών
+      area_name: Νότιος Τομέας Αθηνών
       country: Greece
       nuts1: EL3
       nuts2: EL30
   - EL305:
-      name: Ανατολική Αττική
+      area_name: Ανατολική Αττική
       country: Greece
       nuts1: EL3
       nuts2: EL30
   - EL306:
-      name: Δυτική Αττική
+      area_name: Δυτική Αττική
       country: Greece
       nuts1: EL3
       nuts2: EL30
   - EL307:
-      name: Πειραιάς, Νήσοι
+      area_name: Πειραιάς, Νήσοι
       country: Greece
       nuts1: EL3
       nuts2: EL30
   - EL411:
-      name: Λέσβος, Λήμνος
+      area_name: Λέσβος, Λήμνος
       country: Greece
       nuts1: EL4
       nuts2: EL41
   - EL412:
-      name: Ικαρία, Σάμος
+      area_name: Ικαρία, Σάμος
       country: Greece
       nuts1: EL4
       nuts2: EL41
   - EL413:
-      name: Χίος
+      area_name: Χίος
       country: Greece
       nuts1: EL4
       nuts2: EL41
   - EL421:
-      name: Κάλυμνος, Κάρπαθος – Ηρωική Νήσος Κάσος, Κως, Ρόδος
+      area_name: Κάλυμνος, Κάρπαθος – Ηρωική Νήσος Κάσος, Κως, Ρόδος
       country: Greece
       nuts1: EL4
       nuts2: EL42
   - EL422:
-      name: Άνδρος, Θήρα, Κέα, Μήλος, Μύκονος, Νάξος, Πάρος, Σύρος, Τήνος
+      area_name: Άνδρος, Θήρα, Κέα, Μήλος, Μύκονος, Νάξος, Πάρος, Σύρος, Τήνος
       country: Greece
       nuts1: EL4
       nuts2: EL42
   - EL431:
-      name: Ηράκλειο
+      area_name: Ηράκλειο
       country: Greece
       nuts1: EL4
       nuts2: EL43
   - EL432:
-      name: Λασίθι
+      area_name: Λασίθι
       country: Greece
       nuts1: EL4
       nuts2: EL43
   - EL433:
-      name: Ρέθυμνο
+      area_name: Ρέθυμνο
       country: Greece
       nuts1: EL4
       nuts2: EL43
   - EL434:
-      name: Χανιά
+      area_name: Χανιά
       country: Greece
       nuts1: EL4
       nuts2: EL43
   - EL511:
-      name: Έβρος
+      area_name: Έβρος
       country: Greece
       nuts1: EL5
       nuts2: EL51
   - EL512:
-      name: Ξάνθη
+      area_name: Ξάνθη
       country: Greece
       nuts1: EL5
       nuts2: EL51
   - EL513:
-      name: Ροδόπη
+      area_name: Ροδόπη
       country: Greece
       nuts1: EL5
       nuts2: EL51
   - EL514:
-      name: Δράμα
+      area_name: Δράμα
       country: Greece
       nuts1: EL5
       nuts2: EL51
   - EL515:
-      name: Θάσος, Καβάλα
+      area_name: Θάσος, Καβάλα
       country: Greece
       nuts1: EL5
       nuts2: EL51
   - EL521:
-      name: Ημαθία
+      area_name: Ημαθία
       country: Greece
       nuts1: EL5
       nuts2: EL52
   - EL522:
-      name: Θεσσαλονίκη
+      area_name: Θεσσαλονίκη
       country: Greece
       nuts1: EL5
       nuts2: EL52
   - EL523:
-      name: Κιλκίς
+      area_name: Κιλκίς
       country: Greece
       nuts1: EL5
       nuts2: EL52
   - EL524:
-      name: Πέλλα
+      area_name: Πέλλα
       country: Greece
       nuts1: EL5
       nuts2: EL52
   - EL525:
-      name: Πιερία
+      area_name: Πιερία
       country: Greece
       nuts1: EL5
       nuts2: EL52
   - EL526:
-      name: Σέρρες
+      area_name: Σέρρες
       country: Greece
       nuts1: EL5
       nuts2: EL52
   - EL527:
-      name: Χαλκιδική
+      area_name: Χαλκιδική
       country: Greece
       nuts1: EL5
       nuts2: EL52
   - EL531:
-      name: Γρεβενά, Κοζάνη
+      area_name: Γρεβενά, Κοζάνη
       country: Greece
       nuts1: EL5
       nuts2: EL53
   - EL532:
-      name: Καστοριά
+      area_name: Καστοριά
       country: Greece
       nuts1: EL5
       nuts2: EL53
   - EL533:
-      name: Φλώρινα
+      area_name: Φλώρινα
       country: Greece
       nuts1: EL5
       nuts2: EL53
   - EL541:
-      name: Άρτα, Πρέβεζα
+      area_name: Άρτα, Πρέβεζα
       country: Greece
       nuts1: EL5
       nuts2: EL54
   - EL542:
-      name: Θεσπρωτία
+      area_name: Θεσπρωτία
       country: Greece
       nuts1: EL5
       nuts2: EL54
   - EL543:
-      name: Ιωάννινα
+      area_name: Ιωάννινα
       country: Greece
       nuts1: EL5
       nuts2: EL54
   - EL611:
-      name: Καρδίτσα, Τρίκαλα
+      area_name: Καρδίτσα, Τρίκαλα
       country: Greece
       nuts1: EL6
       nuts2: EL61
   - EL612:
-      name: Λάρισα
+      area_name: Λάρισα
       country: Greece
       nuts1: EL6
       nuts2: EL61
   - EL613:
-      name: Μαγνησία, Σποράδες
+      area_name: Μαγνησία, Σποράδες
       country: Greece
       nuts1: EL6
       nuts2: EL61
   - EL621:
-      name: Ζάκυνθος
+      area_name: Ζάκυνθος
       country: Greece
       nuts1: EL6
       nuts2: EL62
   - EL622:
-      name: Κέρκυρα
+      area_name: Κέρκυρα
       country: Greece
       nuts1: EL6
       nuts2: EL62
   - EL623:
-      name: Ιθάκη, Κεφαλληνία
+      area_name: Ιθάκη, Κεφαλληνία
       country: Greece
       nuts1: EL6
       nuts2: EL62
   - EL624:
-      name: Λευκάδα
+      area_name: Λευκάδα
       country: Greece
       nuts1: EL6
       nuts2: EL62
   - EL631:
-      name: Αιτωλοακαρνανία
+      area_name: Αιτωλοακαρνανία
       country: Greece
       nuts1: EL6
       nuts2: EL63
   - EL632:
-      name: Αχαΐα
+      area_name: Αχαΐα
       country: Greece
       nuts1: EL6
       nuts2: EL63
   - EL633:
-      name: Ηλεία
+      area_name: Ηλεία
       country: Greece
       nuts1: EL6
       nuts2: EL63
   - EL641:
-      name: Βοιωτία
+      area_name: Βοιωτία
       country: Greece
       nuts1: EL6
       nuts2: EL64
   - EL642:
-      name: Εύβοια
+      area_name: Εύβοια
       country: Greece
       nuts1: EL6
       nuts2: EL64
   - EL643:
-      name: Ευρυτανία
+      area_name: Ευρυτανία
       country: Greece
       nuts1: EL6
       nuts2: EL64
   - EL644:
-      name: Φθιώτιδα
+      area_name: Φθιώτιδα
       country: Greece
       nuts1: EL6
       nuts2: EL64
   - EL645:
-      name: Φωκίδα
+      area_name: Φωκίδα
       country: Greece
       nuts1: EL6
       nuts2: EL64
   - EL651:
-      name: Αργολίδα, Αρκαδία
+      area_name: Αργολίδα, Αρκαδία
       country: Greece
       nuts1: EL6
       nuts2: EL65
   - EL652:
-      name: Κορινθία
+      area_name: Κορινθία
       country: Greece
       nuts1: EL6
       nuts2: EL65
   - EL653:
-      name: Λακωνία, Μεσσηνία
+      area_name: Λακωνία, Μεσσηνία
       country: Greece
       nuts1: EL6
       nuts2: EL65
   - ELZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Greece
       nuts1: ELZ
       nuts2: ELZZ
   - ES111:
-      name: A Coruña
+      area_name: A Coruña
       country: Spain
       nuts1: ES1
       nuts2: ES11
   - ES112:
-      name: Lugo
+      area_name: Lugo
       country: Spain
       nuts1: ES1
       nuts2: ES11
   - ES113:
-      name: Ourense
+      area_name: Ourense
       country: Spain
       nuts1: ES1
       nuts2: ES11
   - ES114:
-      name: Pontevedra
+      area_name: Pontevedra
       country: Spain
       nuts1: ES1
       nuts2: ES11
   - ES120:
-      name: Asturias
+      area_name: Asturias
       country: Spain
       nuts1: ES1
       nuts2: ES12
   - ES130:
-      name: Cantabria
+      area_name: Cantabria
       country: Spain
       nuts1: ES1
       nuts2: ES13
   - ES211:
-      name: Araba/Álava
+      area_name: Araba/Álava
       country: Spain
       nuts1: ES2
       nuts2: ES21
   - ES212:
-      name: Gipuzkoa
+      area_name: Gipuzkoa
       country: Spain
       nuts1: ES2
       nuts2: ES21
   - ES213:
-      name: Bizkaia
+      area_name: Bizkaia
       country: Spain
       nuts1: ES2
       nuts2: ES21
   - ES220:
-      name: Navarra
+      area_name: Navarra
       country: Spain
       nuts1: ES2
       nuts2: ES22
   - ES230:
-      name: La Rioja
+      area_name: La Rioja
       country: Spain
       nuts1: ES2
       nuts2: ES23
   - ES241:
-      name: Huesca
+      area_name: Huesca
       country: Spain
       nuts1: ES2
       nuts2: ES24
   - ES242:
-      name: Teruel
+      area_name: Teruel
       country: Spain
       nuts1: ES2
       nuts2: ES24
   - ES243:
-      name: Zaragoza
+      area_name: Zaragoza
       country: Spain
       nuts1: ES2
       nuts2: ES24
   - ES300:
-      name: Madrid
+      area_name: Madrid
       country: Spain
       nuts1: ES3
       nuts2: ES30
   - ES411:
-      name: Ávila
+      area_name: Ávila
       country: Spain
       nuts1: ES4
       nuts2: ES41
   - ES412:
-      name: Burgos
+      area_name: Burgos
       country: Spain
       nuts1: ES4
       nuts2: ES41
   - ES413:
-      name: León
+      area_name: León
       country: Spain
       nuts1: ES4
       nuts2: ES41
   - ES414:
-      name: Palencia
+      area_name: Palencia
       country: Spain
       nuts1: ES4
       nuts2: ES41
   - ES415:
-      name: Salamanca
+      area_name: Salamanca
       country: Spain
       nuts1: ES4
       nuts2: ES41
   - ES416:
-      name: Segovia
+      area_name: Segovia
       country: Spain
       nuts1: ES4
       nuts2: ES41
   - ES417:
-      name: Soria
+      area_name: Soria
       country: Spain
       nuts1: ES4
       nuts2: ES41
   - ES418:
-      name: Valladolid
+      area_name: Valladolid
       country: Spain
       nuts1: ES4
       nuts2: ES41
   - ES419:
-      name: Zamora
+      area_name: Zamora
       country: Spain
       nuts1: ES4
       nuts2: ES41
   - ES421:
-      name: Albacete
+      area_name: Albacete
       country: Spain
       nuts1: ES4
       nuts2: ES42
   - ES422:
-      name: Ciudad Real
+      area_name: Ciudad Real
       country: Spain
       nuts1: ES4
       nuts2: ES42
   - ES423:
-      name: Cuenca
+      area_name: Cuenca
       country: Spain
       nuts1: ES4
       nuts2: ES42
   - ES424:
-      name: Guadalajara
+      area_name: Guadalajara
       country: Spain
       nuts1: ES4
       nuts2: ES42
   - ES425:
-      name: Toledo
+      area_name: Toledo
       country: Spain
       nuts1: ES4
       nuts2: ES42
   - ES431:
-      name: Badajoz
+      area_name: Badajoz
       country: Spain
       nuts1: ES4
       nuts2: ES43
   - ES432:
-      name: Cáceres
+      area_name: Cáceres
       country: Spain
       nuts1: ES4
       nuts2: ES43
   - ES511:
-      name: Barcelona
+      area_name: Barcelona
       country: Spain
       nuts1: ES5
       nuts2: ES51
   - ES512:
-      name: Girona
+      area_name: Girona
       country: Spain
       nuts1: ES5
       nuts2: ES51
   - ES513:
-      name: Lleida
+      area_name: Lleida
       country: Spain
       nuts1: ES5
       nuts2: ES51
   - ES514:
-      name: Tarragona
+      area_name: Tarragona
       country: Spain
       nuts1: ES5
       nuts2: ES51
   - ES521:
-      name: Alicante/Alacant
+      area_name: Alicante/Alacant
       country: Spain
       nuts1: ES5
       nuts2: ES52
   - ES522:
-      name: Castellón/Castelló
+      area_name: Castellón/Castelló
       country: Spain
       nuts1: ES5
       nuts2: ES52
   - ES523:
-      name: Valencia/València
+      area_name: Valencia/València
       country: Spain
       nuts1: ES5
       nuts2: ES52
   - ES531:
-      name: Eivissa y Formentera
+      area_name: Eivissa y Formentera
       country: Spain
       nuts1: ES5
       nuts2: ES53
   - ES532:
-      name: Mallorca
+      area_name: Mallorca
       country: Spain
       nuts1: ES5
       nuts2: ES53
   - ES533:
-      name: Menorca
+      area_name: Menorca
       country: Spain
       nuts1: ES5
       nuts2: ES53
   - ES611:
-      name: Almería
+      area_name: Almería
       country: Spain
       nuts1: ES6
       nuts2: ES61
   - ES612:
-      name: Cádiz
+      area_name: Cádiz
       country: Spain
       nuts1: ES6
       nuts2: ES61
   - ES613:
-      name: Córdoba
+      area_name: Córdoba
       country: Spain
       nuts1: ES6
       nuts2: ES61
   - ES614:
-      name: Granada
+      area_name: Granada
       country: Spain
       nuts1: ES6
       nuts2: ES61
   - ES615:
-      name: Huelva
+      area_name: Huelva
       country: Spain
       nuts1: ES6
       nuts2: ES61
   - ES616:
-      name: Jaén
+      area_name: Jaén
       country: Spain
       nuts1: ES6
       nuts2: ES61
   - ES617:
-      name: Málaga
+      area_name: Málaga
       country: Spain
       nuts1: ES6
       nuts2: ES61
   - ES618:
-      name: Sevilla
+      area_name: Sevilla
       country: Spain
       nuts1: ES6
       nuts2: ES61
   - ES620:
-      name: Murcia
+      area_name: Murcia
       country: Spain
       nuts1: ES6
       nuts2: ES62
   - ES630:
-      name: Ceuta
+      area_name: Ceuta
       country: Spain
       nuts1: ES6
       nuts2: ES63
   - ES640:
-      name: Melilla
+      area_name: Melilla
       country: Spain
       nuts1: ES6
       nuts2: ES64
   - ES703:
-      name: El Hierro
+      area_name: El Hierro
       country: Spain
       nuts1: ES7
       nuts2: ES70
   - ES704:
-      name: Fuerteventura
+      area_name: Fuerteventura
       country: Spain
       nuts1: ES7
       nuts2: ES70
   - ES705:
-      name: Gran Canaria
+      area_name: Gran Canaria
       country: Spain
       nuts1: ES7
       nuts2: ES70
   - ES706:
-      name: La Gomera
+      area_name: La Gomera
       country: Spain
       nuts1: ES7
       nuts2: ES70
   - ES707:
-      name: La Palma
+      area_name: La Palma
       country: Spain
       nuts1: ES7
       nuts2: ES70
   - ES708:
-      name: Lanzarote
+      area_name: Lanzarote
       country: Spain
       nuts1: ES7
       nuts2: ES70
   - ES709:
-      name: Tenerife
+      area_name: Tenerife
       country: Spain
       nuts1: ES7
       nuts2: ES70
   - ESZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Spain
       nuts1: ESZ
       nuts2: ESZZ
   - FR101:
-      name: Paris
+      area_name: Paris
       country: France
       nuts1: FR1
       nuts2: FR10
   - FR102:
-      name: Seine-et-Marne 
+      area_name: Seine-et-Marne 
       country: France
       nuts1: FR1
       nuts2: FR10
   - FR103:
-      name: Yvelines 
+      area_name: Yvelines 
       country: France
       nuts1: FR1
       nuts2: FR10
   - FR104:
-      name: Essonne
+      area_name: Essonne
       country: France
       nuts1: FR1
       nuts2: FR10
   - FR105:
-      name: Hauts-de-Seine 
+      area_name: Hauts-de-Seine 
       country: France
       nuts1: FR1
       nuts2: FR10
   - FR106:
-      name: Seine-Saint-Denis 
+      area_name: Seine-Saint-Denis 
       country: France
       nuts1: FR1
       nuts2: FR10
   - FR107:
-      name: Val-de-Marne
+      area_name: Val-de-Marne
       country: France
       nuts1: FR1
       nuts2: FR10
   - FR108:
-      name: Val-d’Oise
+      area_name: Val-d’Oise
       country: France
       nuts1: FR1
       nuts2: FR10
   - FRB01:
-      name: Cher
+      area_name: Cher
       country: France
       nuts1: FRB
       nuts2: FRB0
   - FRB02:
-      name: Eure-et-Loir
+      area_name: Eure-et-Loir
       country: France
       nuts1: FRB
       nuts2: FRB0
   - FRB03:
-      name: Indre
+      area_name: Indre
       country: France
       nuts1: FRB
       nuts2: FRB0
   - FRB04:
-      name: Indre-et-Loire
+      area_name: Indre-et-Loire
       country: France
       nuts1: FRB
       nuts2: FRB0
   - FRB05:
-      name: Loir-et-Cher
+      area_name: Loir-et-Cher
       country: France
       nuts1: FRB
       nuts2: FRB0
   - FRB06:
-      name: Loiret
+      area_name: Loiret
       country: France
       nuts1: FRB
       nuts2: FRB0
   - FRC11:
-      name: Côte-d’Or
+      area_name: Côte-d’Or
       country: France
       nuts1: FRC
       nuts2: FRC1
   - FRC12:
-      name: Nièvre
+      area_name: Nièvre
       country: France
       nuts1: FRC
       nuts2: FRC1
   - FRC13:
-      name: Saône-et-Loire
+      area_name: Saône-et-Loire
       country: France
       nuts1: FRC
       nuts2: FRC1
   - FRC14:
-      name: Yonne
+      area_name: Yonne
       country: France
       nuts1: FRC
       nuts2: FRC1
   - FRC21:
-      name: Doubs
+      area_name: Doubs
       country: France
       nuts1: FRC
       nuts2: FRC2
   - FRC22:
-      name: Jura
+      area_name: Jura
       country: France
       nuts1: FRC
       nuts2: FRC2
   - FRC23:
-      name: Haute-Saône
+      area_name: Haute-Saône
       country: France
       nuts1: FRC
       nuts2: FRC2
   - FRC24:
-      name: Territoire de Belfort
+      area_name: Territoire de Belfort
       country: France
       nuts1: FRC
       nuts2: FRC2
   - FRD11:
-      name: Calvados 
+      area_name: Calvados 
       country: France
       nuts1: FRD
       nuts2: FRD1
   - FRD12:
-      name: Manche 
+      area_name: Manche 
       country: France
       nuts1: FRD
       nuts2: FRD1
   - FRD13:
-      name: Orne
+      area_name: Orne
       country: France
       nuts1: FRD
       nuts2: FRD1
   - FRD21:
-      name: Eure
+      area_name: Eure
       country: France
       nuts1: FRD
       nuts2: FRD2
   - FRD22:
-      name: Seine-Maritime
+      area_name: Seine-Maritime
       country: France
       nuts1: FRD
       nuts2: FRD2
   - FRE11:
-      name: Nord
+      area_name: Nord
       country: France
       nuts1: FRE
       nuts2: FRE1
   - FRE12:
-      name: Pas-de-Calais
+      area_name: Pas-de-Calais
       country: France
       nuts1: FRE
       nuts2: FRE1
   - FRE21:
-      name: Aisne
+      area_name: Aisne
       country: France
       nuts1: FRE
       nuts2: FRE2
   - FRE22:
-      name: Oise
+      area_name: Oise
       country: France
       nuts1: FRE
       nuts2: FRE2
   - FRE23:
-      name: Somme
+      area_name: Somme
       country: France
       nuts1: FRE
       nuts2: FRE2
   - FRF11:
-      name: Bas-Rhin
+      area_name: Bas-Rhin
       country: France
       nuts1: FRF
       nuts2: FRF1
   - FRF12:
-      name: Haut-Rhin
+      area_name: Haut-Rhin
       country: France
       nuts1: FRF
       nuts2: FRF1
   - FRF21:
-      name: Ardennes
+      area_name: Ardennes
       country: France
       nuts1: FRF
       nuts2: FRF2
   - FRF22:
-      name: Aube
+      area_name: Aube
       country: France
       nuts1: FRF
       nuts2: FRF2
   - FRF23:
-      name: Marne
+      area_name: Marne
       country: France
       nuts1: FRF
       nuts2: FRF2
   - FRF24:
-      name: Haute-Marne
+      area_name: Haute-Marne
       country: France
       nuts1: FRF
       nuts2: FRF2
   - FRF31:
-      name: Meurthe-et-Moselle 
+      area_name: Meurthe-et-Moselle 
       country: France
       nuts1: FRF
       nuts2: FRF3
   - FRF32:
-      name: Meuse 
+      area_name: Meuse 
       country: France
       nuts1: FRF
       nuts2: FRF3
   - FRF33:
-      name: Moselle
+      area_name: Moselle
       country: France
       nuts1: FRF
       nuts2: FRF3
   - FRF34:
-      name: Vosges
+      area_name: Vosges
       country: France
       nuts1: FRF
       nuts2: FRF3
   - FRG01:
-      name: Loire-Atlantique
+      area_name: Loire-Atlantique
       country: France
       nuts1: FRG
       nuts2: FRG0
   - FRG02:
-      name: Maine-et-Loire
+      area_name: Maine-et-Loire
       country: France
       nuts1: FRG
       nuts2: FRG0
   - FRG03:
-      name: Mayenne
+      area_name: Mayenne
       country: France
       nuts1: FRG
       nuts2: FRG0
   - FRG04:
-      name: Sarthe
+      area_name: Sarthe
       country: France
       nuts1: FRG
       nuts2: FRG0
   - FRG05:
-      name: Vendée
+      area_name: Vendée
       country: France
       nuts1: FRG
       nuts2: FRG0
   - FRH01:
-      name: Côtes-d’Armor
+      area_name: Côtes-d’Armor
       country: France
       nuts1: FRH
       nuts2: FRH0
   - FRH02:
-      name: Finistère
+      area_name: Finistère
       country: France
       nuts1: FRH
       nuts2: FRH0
   - FRH03:
-      name: Ille-et-Vilaine
+      area_name: Ille-et-Vilaine
       country: France
       nuts1: FRH
       nuts2: FRH0
   - FRH04:
-      name: Morbihan
+      area_name: Morbihan
       country: France
       nuts1: FRH
       nuts2: FRH0
   - FRI11:
-      name: Dordogne
+      area_name: Dordogne
       country: France
       nuts1: FRI
       nuts2: FRI1
   - FRI12:
-      name: Gironde
+      area_name: Gironde
       country: France
       nuts1: FRI
       nuts2: FRI1
   - FRI13:
-      name: Landes
+      area_name: Landes
       country: France
       nuts1: FRI
       nuts2: FRI1
   - FRI14:
-      name: Lot-et-Garonne
+      area_name: Lot-et-Garonne
       country: France
       nuts1: FRI
       nuts2: FRI1
   - FRI15:
-      name: Pyrénées-Atlantiques
+      area_name: Pyrénées-Atlantiques
       country: France
       nuts1: FRI
       nuts2: FRI1
   - FRI21:
-      name: Corrèze
+      area_name: Corrèze
       country: France
       nuts1: FRI
       nuts2: FRI2
   - FRI22:
-      name: Creuse
+      area_name: Creuse
       country: France
       nuts1: FRI
       nuts2: FRI2
   - FRI23:
-      name: Haute-Vienne
+      area_name: Haute-Vienne
       country: France
       nuts1: FRI
       nuts2: FRI2
   - FRI31:
-      name: Charente
+      area_name: Charente
       country: France
       nuts1: FRI
       nuts2: FRI3
   - FRI32:
-      name: Charente-Maritime
+      area_name: Charente-Maritime
       country: France
       nuts1: FRI
       nuts2: FRI3
   - FRI33:
-      name: Deux-Sèvres
+      area_name: Deux-Sèvres
       country: France
       nuts1: FRI
       nuts2: FRI3
   - FRI34:
-      name: Vienne
+      area_name: Vienne
       country: France
       nuts1: FRI
       nuts2: FRI3
   - FRJ11:
-      name: Aude
+      area_name: Aude
       country: France
       nuts1: FRJ
       nuts2: FRJ1
   - FRJ12:
-      name: Gard
+      area_name: Gard
       country: France
       nuts1: FRJ
       nuts2: FRJ1
   - FRJ13:
-      name: Hérault
+      area_name: Hérault
       country: France
       nuts1: FRJ
       nuts2: FRJ1
   - FRJ14:
-      name: Lozère
+      area_name: Lozère
       country: France
       nuts1: FRJ
       nuts2: FRJ1
   - FRJ15:
-      name: Pyrénées-Orientales
+      area_name: Pyrénées-Orientales
       country: France
       nuts1: FRJ
       nuts2: FRJ1
   - FRJ21:
-      name: Ariège
+      area_name: Ariège
       country: France
       nuts1: FRJ
       nuts2: FRJ2
   - FRJ22:
-      name: Aveyron
+      area_name: Aveyron
       country: France
       nuts1: FRJ
       nuts2: FRJ2
   - FRJ23:
-      name: Haute-Garonne
+      area_name: Haute-Garonne
       country: France
       nuts1: FRJ
       nuts2: FRJ2
   - FRJ24:
-      name: Gers
+      area_name: Gers
       country: France
       nuts1: FRJ
       nuts2: FRJ2
   - FRJ25:
-      name: Lot
+      area_name: Lot
       country: France
       nuts1: FRJ
       nuts2: FRJ2
   - FRJ26:
-      name: Hautes-Pyrénées 
+      area_name: Hautes-Pyrénées 
       country: France
       nuts1: FRJ
       nuts2: FRJ2
   - FRJ27:
-      name: Tarn
+      area_name: Tarn
       country: France
       nuts1: FRJ
       nuts2: FRJ2
   - FRJ28:
-      name: Tarn-et-Garonne
+      area_name: Tarn-et-Garonne
       country: France
       nuts1: FRJ
       nuts2: FRJ2
   - FRK11:
-      name: Allier
+      area_name: Allier
       country: France
       nuts1: FRK
       nuts2: FRK1
   - FRK12:
-      name: Cantal
+      area_name: Cantal
       country: France
       nuts1: FRK
       nuts2: FRK1
   - FRK13:
-      name: Haute-Loire
+      area_name: Haute-Loire
       country: France
       nuts1: FRK
       nuts2: FRK1
   - FRK14:
-      name: Puy-de-Dôme
+      area_name: Puy-de-Dôme
       country: France
       nuts1: FRK
       nuts2: FRK1
   - FRK21:
-      name: Ain
+      area_name: Ain
       country: France
       nuts1: FRK
       nuts2: FRK2
   - FRK22:
-      name: Ardèche
+      area_name: Ardèche
       country: France
       nuts1: FRK
       nuts2: FRK2
   - FRK23:
-      name: Drôme
+      area_name: Drôme
       country: France
       nuts1: FRK
       nuts2: FRK2
   - FRK24:
-      name: Isère
+      area_name: Isère
       country: France
       nuts1: FRK
       nuts2: FRK2
   - FRK25:
-      name: Loire
+      area_name: Loire
       country: France
       nuts1: FRK
       nuts2: FRK2
   - FRK26:
-      name: Rhône
+      area_name: Rhône
       country: France
       nuts1: FRK
       nuts2: FRK2
   - FRK27:
-      name: Savoie
+      area_name: Savoie
       country: France
       nuts1: FRK
       nuts2: FRK2
   - FRK28:
-      name: Haute-Savoie
+      area_name: Haute-Savoie
       country: France
       nuts1: FRK
       nuts2: FRK2
   - FRL01:
-      name: Alpes-de-Haute-Provence
+      area_name: Alpes-de-Haute-Provence
       country: France
       nuts1: FRL
       nuts2: FRL0
   - FRL02:
-      name: Hautes-Alpes 
+      area_name: Hautes-Alpes 
       country: France
       nuts1: FRL
       nuts2: FRL0
   - FRL03:
-      name: Alpes-Maritimes
+      area_name: Alpes-Maritimes
       country: France
       nuts1: FRL
       nuts2: FRL0
   - FRL04:
-      name: Bouches-du-Rhône
+      area_name: Bouches-du-Rhône
       country: France
       nuts1: FRL
       nuts2: FRL0
   - FRL05:
-      name: Var
+      area_name: Var
       country: France
       nuts1: FRL
       nuts2: FRL0
   - FRL06:
-      name: Vaucluse
+      area_name: Vaucluse
       country: France
       nuts1: FRL
       nuts2: FRL0
   - FRM01:
-      name: Corse-du-Sud
+      area_name: Corse-du-Sud
       country: France
       nuts1: FRM
       nuts2: FRM0
   - FRM02:
-      name: Haute-Corse
+      area_name: Haute-Corse
       country: France
       nuts1: FRM
       nuts2: FRM0
   - FRY10:
-      name: Guadeloupe
+      area_name: Guadeloupe
       country: France
       nuts1: FRY
       nuts2: FRY1
   - FRY20:
-      name: Martinique 
+      area_name: Martinique 
       country: France
       nuts1: FRY
       nuts2: FRY2
   - FRY30:
-      name: Guyane
+      area_name: Guyane
       country: France
       nuts1: FRY
       nuts2: FRY3
   - FRY40:
-      name: La Réunion
+      area_name: La Réunion
       country: France
       nuts1: FRY
       nuts2: FRY4
   - FRY50:
-      name: Mayotte 
+      area_name: Mayotte 
       country: France
       nuts1: FRY
       nuts2: FRY5
   - FRZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: France
       nuts1: FRZ
       nuts2: FRZZ
   - HR021:
-      name: Bjelovarsko-bilogorska županija
+      area_name: Bjelovarsko-bilogorska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR02
   - HR022:
-      name: Virovitičko-podravska županija
+      area_name: Virovitičko-podravska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR02
   - HR023:
-      name: Požeško-slavonska županija
+      area_name: Požeško-slavonska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR02
   - HR024:
-      name: Brodsko-posavska županija
+      area_name: Brodsko-posavska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR02
   - HR025:
-      name: Osječko-baranjska županija
+      area_name: Osječko-baranjska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR02
   - HR026:
-      name: Vukovarsko-srijemska županija
+      area_name: Vukovarsko-srijemska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR02
   - HR027:
-      name: Karlovačka županija
+      area_name: Karlovačka županija
       country: Croatia
       nuts1: HR0
       nuts2: HR02
   - HR028:
-      name: Sisačko-moslavačka županija
+      area_name: Sisačko-moslavačka županija
       country: Croatia
       nuts1: HR0
       nuts2: HR02
   - HR031:
-      name: Primorsko-goranska županija
+      area_name: Primorsko-goranska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR03
   - HR032:
-      name: Ličko-senjska županija
+      area_name: Ličko-senjska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR03
   - HR033:
-      name: Zadarska županija
+      area_name: Zadarska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR03
   - HR034:
-      name: Šibensko-kninska županija
+      area_name: Šibensko-kninska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR03
   - HR035:
-      name: Splitsko-dalmatinska županija
+      area_name: Splitsko-dalmatinska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR03
   - HR036:
-      name: Istarska županija
+      area_name: Istarska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR03
   - HR037:
-      name: Dubrovačko-neretvanska županija
+      area_name: Dubrovačko-neretvanska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR03
   - HR050:
-      name: Grad Zagreb
+      area_name: Grad Zagreb
       country: Croatia
       nuts1: HR0
       nuts2: HR05
   - HR061:
-      name: Međimurska županija
+      area_name: Međimurska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR06
   - HR062:
-      name: Varaždinska županija
+      area_name: Varaždinska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR06
   - HR063:
-      name: Koprivničko-križevačka županija
+      area_name: Koprivničko-križevačka županija
       country: Croatia
       nuts1: HR0
       nuts2: HR06
   - HR064:
-      name: Krapinsko-zagorska županija
+      area_name: Krapinsko-zagorska županija
       country: Croatia
       nuts1: HR0
       nuts2: HR06
   - HR065:
-      name: Zagrebačka županija
+      area_name: Zagrebačka županija
       country: Croatia
       nuts1: HR0
       nuts2: HR06
   - HRZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Croatia
       nuts1: HRZ
       nuts2: HRZZ
   - ITC11:
-      name: Torino
+      area_name: Torino
       country: Italy
       nuts1: ITC
       nuts2: ITC1
   - ITC12:
-      name: Vercelli
+      area_name: Vercelli
       country: Italy
       nuts1: ITC
       nuts2: ITC1
   - ITC13:
-      name: Biella
+      area_name: Biella
       country: Italy
       nuts1: ITC
       nuts2: ITC1
   - ITC14:
-      name: Verbano-Cusio-Ossola
+      area_name: Verbano-Cusio-Ossola
       country: Italy
       nuts1: ITC
       nuts2: ITC1
   - ITC15:
-      name: Novara
+      area_name: Novara
       country: Italy
       nuts1: ITC
       nuts2: ITC1
   - ITC16:
-      name: Cuneo
+      area_name: Cuneo
       country: Italy
       nuts1: ITC
       nuts2: ITC1
   - ITC17:
-      name: Asti
+      area_name: Asti
       country: Italy
       nuts1: ITC
       nuts2: ITC1
   - ITC18:
-      name: Alessandria
+      area_name: Alessandria
       country: Italy
       nuts1: ITC
       nuts2: ITC1
   - ITC20:
-      name: Valle d’Aosta/Vallée d’Aoste
+      area_name: Valle d’Aosta/Vallée d’Aoste
       country: Italy
       nuts1: ITC
       nuts2: ITC2
   - ITC31:
-      name: Imperia
+      area_name: Imperia
       country: Italy
       nuts1: ITC
       nuts2: ITC3
   - ITC32:
-      name: Savona
+      area_name: Savona
       country: Italy
       nuts1: ITC
       nuts2: ITC3
   - ITC33:
-      name: Genova
+      area_name: Genova
       country: Italy
       nuts1: ITC
       nuts2: ITC3
   - ITC34:
-      name: La Spezia
+      area_name: La Spezia
       country: Italy
       nuts1: ITC
       nuts2: ITC3
   - ITC41:
-      name: Varese
+      area_name: Varese
       country: Italy
       nuts1: ITC
       nuts2: ITC4
   - ITC42:
-      name: Como
+      area_name: Como
       country: Italy
       nuts1: ITC
       nuts2: ITC4
   - ITC43:
-      name: Lecco
+      area_name: Lecco
       country: Italy
       nuts1: ITC
       nuts2: ITC4
   - ITC44:
-      name: Sondrio
+      area_name: Sondrio
       country: Italy
       nuts1: ITC
       nuts2: ITC4
   - ITC46:
-      name: Bergamo
+      area_name: Bergamo
       country: Italy
       nuts1: ITC
       nuts2: ITC4
   - ITC47:
-      name: Brescia
+      area_name: Brescia
       country: Italy
       nuts1: ITC
       nuts2: ITC4
   - ITC48:
-      name: Pavia
+      area_name: Pavia
       country: Italy
       nuts1: ITC
       nuts2: ITC4
   - ITC49:
-      name: Lodi
+      area_name: Lodi
       country: Italy
       nuts1: ITC
       nuts2: ITC4
   - ITC4A:
-      name: Cremona
+      area_name: Cremona
       country: Italy
       nuts1: ITC
       nuts2: ITC4
   - ITC4B:
-      name: Mantova
+      area_name: Mantova
       country: Italy
       nuts1: ITC
       nuts2: ITC4
   - ITC4C:
-      name: Milano
+      area_name: Milano
       country: Italy
       nuts1: ITC
       nuts2: ITC4
   - ITC4D:
-      name: Monza e della Brianza
+      area_name: Monza e della Brianza
       country: Italy
       nuts1: ITC
       nuts2: ITC4
   - ITF11:
-      name: L’Aquila
+      area_name: L’Aquila
       country: Italy
       nuts1: ITF
       nuts2: ITF1
   - ITF12:
-      name: Teramo
+      area_name: Teramo
       country: Italy
       nuts1: ITF
       nuts2: ITF1
   - ITF13:
-      name: Pescara
+      area_name: Pescara
       country: Italy
       nuts1: ITF
       nuts2: ITF1
   - ITF14:
-      name: Chieti
+      area_name: Chieti
       country: Italy
       nuts1: ITF
       nuts2: ITF1
   - ITF21:
-      name: Isernia
+      area_name: Isernia
       country: Italy
       nuts1: ITF
       nuts2: ITF2
   - ITF22:
-      name: Campobasso
+      area_name: Campobasso
       country: Italy
       nuts1: ITF
       nuts2: ITF2
   - ITF31:
-      name: Caserta
+      area_name: Caserta
       country: Italy
       nuts1: ITF
       nuts2: ITF3
   - ITF32:
-      name: Benevento
+      area_name: Benevento
       country: Italy
       nuts1: ITF
       nuts2: ITF3
   - ITF33:
-      name: Napoli
+      area_name: Napoli
       country: Italy
       nuts1: ITF
       nuts2: ITF3
   - ITF34:
-      name: Avellino
+      area_name: Avellino
       country: Italy
       nuts1: ITF
       nuts2: ITF3
   - ITF35:
-      name: Salerno
+      area_name: Salerno
       country: Italy
       nuts1: ITF
       nuts2: ITF3
   - ITF43:
-      name: Taranto
+      area_name: Taranto
       country: Italy
       nuts1: ITF
       nuts2: ITF4
   - ITF44:
-      name: Brindisi
+      area_name: Brindisi
       country: Italy
       nuts1: ITF
       nuts2: ITF4
   - ITF45:
-      name: Lecce
+      area_name: Lecce
       country: Italy
       nuts1: ITF
       nuts2: ITF4
   - ITF46:
-      name: Foggia
+      area_name: Foggia
       country: Italy
       nuts1: ITF
       nuts2: ITF4
   - ITF47:
-      name: Bari
+      area_name: Bari
       country: Italy
       nuts1: ITF
       nuts2: ITF4
   - ITF48:
-      name: Barletta-Andria-Trani
+      area_name: Barletta-Andria-Trani
       country: Italy
       nuts1: ITF
       nuts2: ITF4
   - ITF51:
-      name: Potenza
+      area_name: Potenza
       country: Italy
       nuts1: ITF
       nuts2: ITF5
   - ITF52:
-      name: Matera
+      area_name: Matera
       country: Italy
       nuts1: ITF
       nuts2: ITF5
   - ITF61:
-      name: Cosenza
+      area_name: Cosenza
       country: Italy
       nuts1: ITF
       nuts2: ITF6
   - ITF62:
-      name: Crotone
+      area_name: Crotone
       country: Italy
       nuts1: ITF
       nuts2: ITF6
   - ITF63:
-      name: Catanzaro
+      area_name: Catanzaro
       country: Italy
       nuts1: ITF
       nuts2: ITF6
   - ITF64:
-      name: Vibo Valentia
+      area_name: Vibo Valentia
       country: Italy
       nuts1: ITF
       nuts2: ITF6
   - ITF65:
-      name: Reggio di Calabria
+      area_name: Reggio di Calabria
       country: Italy
       nuts1: ITF
       nuts2: ITF6
   - ITG11:
-      name: Trapani
+      area_name: Trapani
       country: Italy
       nuts1: ITG
       nuts2: ITG1
   - ITG12:
-      name: Palermo
+      area_name: Palermo
       country: Italy
       nuts1: ITG
       nuts2: ITG1
   - ITG13:
-      name: Messina
+      area_name: Messina
       country: Italy
       nuts1: ITG
       nuts2: ITG1
   - ITG14:
-      name: Agrigento
+      area_name: Agrigento
       country: Italy
       nuts1: ITG
       nuts2: ITG1
   - ITG15:
-      name: Caltanissetta
+      area_name: Caltanissetta
       country: Italy
       nuts1: ITG
       nuts2: ITG1
   - ITG16:
-      name: Enna
+      area_name: Enna
       country: Italy
       nuts1: ITG
       nuts2: ITG1
   - ITG17:
-      name: Catania
+      area_name: Catania
       country: Italy
       nuts1: ITG
       nuts2: ITG1
   - ITG18:
-      name: Ragusa
+      area_name: Ragusa
       country: Italy
       nuts1: ITG
       nuts2: ITG1
   - ITG19:
-      name: Siracusa
+      area_name: Siracusa
       country: Italy
       nuts1: ITG
       nuts2: ITG1
   - ITG2D:
-      name: Sassari
+      area_name: Sassari
       country: Italy
       nuts1: ITG
       nuts2: ITG2
   - ITG2E:
-      name: Nuoro
+      area_name: Nuoro
       country: Italy
       nuts1: ITG
       nuts2: ITG2
   - ITG2F:
-      name: Cagliari
+      area_name: Cagliari
       country: Italy
       nuts1: ITG
       nuts2: ITG2
   - ITG2G:
-      name: Oristano
+      area_name: Oristano
       country: Italy
       nuts1: ITG
       nuts2: ITG2
   - ITG2H:
-      name: Sud Sardegna
+      area_name: Sud Sardegna
       country: Italy
       nuts1: ITG
       nuts2: ITG2
   - ITH10:
-      name: Bolzano-Bozen
+      area_name: Bolzano-Bozen
       country: Italy
       nuts1: ITH
       nuts2: ITH1
   - ITH20:
-      name: Trento
+      area_name: Trento
       country: Italy
       nuts1: ITH
       nuts2: ITH2
   - ITH31:
-      name: Verona
+      area_name: Verona
       country: Italy
       nuts1: ITH
       nuts2: ITH3
   - ITH32:
-      name: Vicenza
+      area_name: Vicenza
       country: Italy
       nuts1: ITH
       nuts2: ITH3
   - ITH33:
-      name: Belluno
+      area_name: Belluno
       country: Italy
       nuts1: ITH
       nuts2: ITH3
   - ITH34:
-      name: Treviso
+      area_name: Treviso
       country: Italy
       nuts1: ITH
       nuts2: ITH3
   - ITH35:
-      name: Venezia
+      area_name: Venezia
       country: Italy
       nuts1: ITH
       nuts2: ITH3
   - ITH36:
-      name: Padova
+      area_name: Padova
       country: Italy
       nuts1: ITH
       nuts2: ITH3
   - ITH37:
-      name: Rovigo
+      area_name: Rovigo
       country: Italy
       nuts1: ITH
       nuts2: ITH3
   - ITH41:
-      name: Pordenone
+      area_name: Pordenone
       country: Italy
       nuts1: ITH
       nuts2: ITH4
   - ITH42:
-      name: Udine
+      area_name: Udine
       country: Italy
       nuts1: ITH
       nuts2: ITH4
   - ITH43:
-      name: Gorizia
+      area_name: Gorizia
       country: Italy
       nuts1: ITH
       nuts2: ITH4
   - ITH44:
-      name: Trieste
+      area_name: Trieste
       country: Italy
       nuts1: ITH
       nuts2: ITH4
   - ITH51:
-      name: Piacenza
+      area_name: Piacenza
       country: Italy
       nuts1: ITH
       nuts2: ITH5
   - ITH52:
-      name: Parma
+      area_name: Parma
       country: Italy
       nuts1: ITH
       nuts2: ITH5
   - ITH53:
-      name: Reggio nell’Emilia
+      area_name: Reggio nell’Emilia
       country: Italy
       nuts1: ITH
       nuts2: ITH5
   - ITH54:
-      name: Modena
+      area_name: Modena
       country: Italy
       nuts1: ITH
       nuts2: ITH5
   - ITH55:
-      name: Bologna
+      area_name: Bologna
       country: Italy
       nuts1: ITH
       nuts2: ITH5
   - ITH56:
-      name: Ferrara
+      area_name: Ferrara
       country: Italy
       nuts1: ITH
       nuts2: ITH5
   - ITH57:
-      name: Ravenna
+      area_name: Ravenna
       country: Italy
       nuts1: ITH
       nuts2: ITH5
   - ITH58:
-      name: Forlì-Cesena
+      area_name: Forlì-Cesena
       country: Italy
       nuts1: ITH
       nuts2: ITH5
   - ITH59:
-      name: Rimini
+      area_name: Rimini
       country: Italy
       nuts1: ITH
       nuts2: ITH5
   - ITI11:
-      name: Massa-Carrara
+      area_name: Massa-Carrara
       country: Italy
       nuts1: ITI
       nuts2: ITI1
   - ITI12:
-      name: Lucca
+      area_name: Lucca
       country: Italy
       nuts1: ITI
       nuts2: ITI1
   - ITI13:
-      name: Pistoia
+      area_name: Pistoia
       country: Italy
       nuts1: ITI
       nuts2: ITI1
   - ITI14:
-      name: Firenze
+      area_name: Firenze
       country: Italy
       nuts1: ITI
       nuts2: ITI1
   - ITI15:
-      name: Prato
+      area_name: Prato
       country: Italy
       nuts1: ITI
       nuts2: ITI1
   - ITI16:
-      name: Livorno
+      area_name: Livorno
       country: Italy
       nuts1: ITI
       nuts2: ITI1
   - ITI17:
-      name: Pisa
+      area_name: Pisa
       country: Italy
       nuts1: ITI
       nuts2: ITI1
   - ITI18:
-      name: Arezzo
+      area_name: Arezzo
       country: Italy
       nuts1: ITI
       nuts2: ITI1
   - ITI19:
-      name: Siena
+      area_name: Siena
       country: Italy
       nuts1: ITI
       nuts2: ITI1
   - ITI1A:
-      name: Grosseto
+      area_name: Grosseto
       country: Italy
       nuts1: ITI
       nuts2: ITI1
   - ITI21:
-      name: Perugia
+      area_name: Perugia
       country: Italy
       nuts1: ITI
       nuts2: ITI2
   - ITI22:
-      name: Terni
+      area_name: Terni
       country: Italy
       nuts1: ITI
       nuts2: ITI2
   - ITI31:
-      name: Pesaro e Urbino
+      area_name: Pesaro e Urbino
       country: Italy
       nuts1: ITI
       nuts2: ITI3
   - ITI32:
-      name: Ancona
+      area_name: Ancona
       country: Italy
       nuts1: ITI
       nuts2: ITI3
   - ITI33:
-      name: Macerata
+      area_name: Macerata
       country: Italy
       nuts1: ITI
       nuts2: ITI3
   - ITI34:
-      name: Ascoli Piceno
+      area_name: Ascoli Piceno
       country: Italy
       nuts1: ITI
       nuts2: ITI3
   - ITI35:
-      name: Fermo
+      area_name: Fermo
       country: Italy
       nuts1: ITI
       nuts2: ITI3
   - ITI41:
-      name: Viterbo
+      area_name: Viterbo
       country: Italy
       nuts1: ITI
       nuts2: ITI4
   - ITI42:
-      name: Rieti
+      area_name: Rieti
       country: Italy
       nuts1: ITI
       nuts2: ITI4
   - ITI43:
-      name: Roma
+      area_name: Roma
       country: Italy
       nuts1: ITI
       nuts2: ITI4
   - ITI44:
-      name: Latina
+      area_name: Latina
       country: Italy
       nuts1: ITI
       nuts2: ITI4
   - ITI45:
-      name: Frosinone
+      area_name: Frosinone
       country: Italy
       nuts1: ITI
       nuts2: ITI4
   - ITZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Italy
       nuts1: ITZ
       nuts2: ITZZ
   - CY000:
-      name: Κύπρος
+      area_name: Κύπρος
       country: Cyprus
       nuts1: CY0
       nuts2: CY00
   - CYZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Cyprus
       nuts1: CYZ
       nuts2: CYZZ
   - LV003:
-      name: Kurzeme
+      area_name: Kurzeme
       country: Latvia
       nuts1: LV0
       nuts2: LV00
   - LV005:
-      name: Latgale
+      area_name: Latgale
       country: Latvia
       nuts1: LV0
       nuts2: LV00
   - LV006:
-      name: Rīga
+      area_name: Rīga
       country: Latvia
       nuts1: LV0
       nuts2: LV00
   - LV007:
-      name: Pierīga
+      area_name: Pierīga
       country: Latvia
       nuts1: LV0
       nuts2: LV00
   - LV008:
-      name: Vidzeme
+      area_name: Vidzeme
       country: Latvia
       nuts1: LV0
       nuts2: LV00
   - LV009:
-      name: Zemgale
+      area_name: Zemgale
       country: Latvia
       nuts1: LV0
       nuts2: LV00
   - LVZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Latvia
       nuts1: LVZ
       nuts2: LVZZ
   - LT011:
-      name: Vilniaus apskritis
+      area_name: Vilniaus apskritis
       country: Lithuania
       nuts1: LT0
       nuts2: LT01
   - LT021:
-      name: Alytaus apskritis
+      area_name: Alytaus apskritis
       country: Lithuania
       nuts1: LT0
       nuts2: LT02
   - LT022:
-      name: Kauno apskritis
+      area_name: Kauno apskritis
       country: Lithuania
       nuts1: LT0
       nuts2: LT02
   - LT023:
-      name: Klaipėdos apskritis
+      area_name: Klaipėdos apskritis
       country: Lithuania
       nuts1: LT0
       nuts2: LT02
   - LT024:
-      name: Marijampolės apskritis
+      area_name: Marijampolės apskritis
       country: Lithuania
       nuts1: LT0
       nuts2: LT02
   - LT025:
-      name: Panevėžio apskritis
+      area_name: Panevėžio apskritis
       country: Lithuania
       nuts1: LT0
       nuts2: LT02
   - LT026:
-      name: Šiaulių apskritis
+      area_name: Šiaulių apskritis
       country: Lithuania
       nuts1: LT0
       nuts2: LT02
   - LT027:
-      name: Tauragės apskritis
+      area_name: Tauragės apskritis
       country: Lithuania
       nuts1: LT0
       nuts2: LT02
   - LT028:
-      name: Telšių apskritis
+      area_name: Telšių apskritis
       country: Lithuania
       nuts1: LT0
       nuts2: LT02
   - LT029:
-      name: Utenos apskritis
+      area_name: Utenos apskritis
       country: Lithuania
       nuts1: LT0
       nuts2: LT02
   - LTZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Lithuania
       nuts1: LTZ
       nuts2: LTZZ
   - LU000:
-      name: Luxembourg
+      area_name: Luxembourg
       country: Luxembourg
       nuts1: LU0
       nuts2: LU00
   - LUZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Luxembourg
       nuts1: LUZ
       nuts2: LUZZ
   - HU110:
-      name: Budapest
+      area_name: Budapest
       country: Hungary
       nuts1: HU1
       nuts2: HU11
   - HU120:
-      name: Pest
+      area_name: Pest
       country: Hungary
       nuts1: HU1
       nuts2: HU12
   - HU211:
-      name: Fejér
+      area_name: Fejér
       country: Hungary
       nuts1: HU2
       nuts2: HU21
   - HU212:
-      name: Komárom-Esztergom
+      area_name: Komárom-Esztergom
       country: Hungary
       nuts1: HU2
       nuts2: HU21
   - HU213:
-      name: Veszprém
+      area_name: Veszprém
       country: Hungary
       nuts1: HU2
       nuts2: HU21
   - HU221:
-      name: Győr-Moson-Sopron
+      area_name: Győr-Moson-Sopron
       country: Hungary
       nuts1: HU2
       nuts2: HU22
   - HU222:
-      name: Vas
+      area_name: Vas
       country: Hungary
       nuts1: HU2
       nuts2: HU22
   - HU223:
-      name: Zala
+      area_name: Zala
       country: Hungary
       nuts1: HU2
       nuts2: HU22
   - HU231:
-      name: Baranya
+      area_name: Baranya
       country: Hungary
       nuts1: HU2
       nuts2: HU23
   - HU232:
-      name: Somogy
+      area_name: Somogy
       country: Hungary
       nuts1: HU2
       nuts2: HU23
   - HU233:
-      name: Tolna
+      area_name: Tolna
       country: Hungary
       nuts1: HU2
       nuts2: HU23
   - HU311:
-      name: Borsod-Abaúj-Zemplén
+      area_name: Borsod-Abaúj-Zemplén
       country: Hungary
       nuts1: HU3
       nuts2: HU31
   - HU312:
-      name: Heves
+      area_name: Heves
       country: Hungary
       nuts1: HU3
       nuts2: HU31
   - HU313:
-      name: Nógrád
+      area_name: Nógrád
       country: Hungary
       nuts1: HU3
       nuts2: HU31
   - HU321:
-      name: Hajdú-Bihar
+      area_name: Hajdú-Bihar
       country: Hungary
       nuts1: HU3
       nuts2: HU32
   - HU322:
-      name: Jász-Nagykun-Szolnok
+      area_name: Jász-Nagykun-Szolnok
       country: Hungary
       nuts1: HU3
       nuts2: HU32
   - HU323:
-      name: Szabolcs-Szatmár-Bereg
+      area_name: Szabolcs-Szatmár-Bereg
       country: Hungary
       nuts1: HU3
       nuts2: HU32
   - HU331:
-      name: Bács-Kiskun
+      area_name: Bács-Kiskun
       country: Hungary
       nuts1: HU3
       nuts2: HU33
   - HU332:
-      name: Békés
+      area_name: Békés
       country: Hungary
       nuts1: HU3
       nuts2: HU33
   - HU333:
-      name: Csongrád
+      area_name: Csongrád
       country: Hungary
       nuts1: HU3
       nuts2: HU33
   - HUZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Hungary
       nuts1: HUZ
       nuts2: HUZZ
   - MT001:
-      name: Malta
+      area_name: Malta
       country: Malta
       nuts1: MT0
       nuts2: MT00
   - MT002:
-      name: Gozo and Comino/Għawdex u Kemmuna
+      area_name: Gozo and Comino/Għawdex u Kemmuna
       country: Malta
       nuts1: MT0
       nuts2: MT00
   - MTZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Malta
       nuts1: MTZ
       nuts2: MTZZ
   - NL111:
-      name: Oost-Groningen
+      area_name: Oost-Groningen
       country: The Netherlands
       nuts1: NL1
       nuts2: NL11
   - NL112:
-      name: Delfzijl en omgeving
+      area_name: Delfzijl en omgeving
       country: The Netherlands
       nuts1: NL1
       nuts2: NL11
   - NL113:
-      name: Overig Groningen
+      area_name: Overig Groningen
       country: The Netherlands
       nuts1: NL1
       nuts2: NL11
   - NL124:
-      name: Noord-Friesland
+      area_name: Noord-Friesland
       country: The Netherlands
       nuts1: NL1
       nuts2: NL12
   - NL125:
-      name: Zuidwest-Friesland
+      area_name: Zuidwest-Friesland
       country: The Netherlands
       nuts1: NL1
       nuts2: NL12
   - NL126:
-      name: Zuidoost-Friesland
+      area_name: Zuidoost-Friesland
       country: The Netherlands
       nuts1: NL1
       nuts2: NL12
   - NL131:
-      name: Noord-Drenthe
+      area_name: Noord-Drenthe
       country: The Netherlands
       nuts1: NL1
       nuts2: NL13
   - NL132:
-      name: Zuidoost-Drenthe
+      area_name: Zuidoost-Drenthe
       country: The Netherlands
       nuts1: NL1
       nuts2: NL13
   - NL133:
-      name: Zuidwest-Drenthe
+      area_name: Zuidwest-Drenthe
       country: The Netherlands
       nuts1: NL1
       nuts2: NL13
   - NL211:
-      name: Noord-Overijssel
+      area_name: Noord-Overijssel
       country: The Netherlands
       nuts1: NL2
       nuts2: NL21
   - NL212:
-      name: Zuidwest-Overijssel
+      area_name: Zuidwest-Overijssel
       country: The Netherlands
       nuts1: NL2
       nuts2: NL21
   - NL213:
-      name: Twente
+      area_name: Twente
       country: The Netherlands
       nuts1: NL2
       nuts2: NL21
   - NL221:
-      name: Veluwe
+      area_name: Veluwe
       country: The Netherlands
       nuts1: NL2
       nuts2: NL22
   - NL224:
-      name: Zuidwest-Gelderland
+      area_name: Zuidwest-Gelderland
       country: The Netherlands
       nuts1: NL2
       nuts2: NL22
   - NL225:
-      name: Achterhoek
+      area_name: Achterhoek
       country: The Netherlands
       nuts1: NL2
       nuts2: NL22
   - NL226:
-      name: Arnhem/Nijmegen
+      area_name: Arnhem/Nijmegen
       country: The Netherlands
       nuts1: NL2
       nuts2: NL22
   - NL230:
-      name: Flevoland
+      area_name: Flevoland
       country: The Netherlands
       nuts1: NL2
       nuts2: NL23
   - NL310:
-      name: Utrecht
+      area_name: Utrecht
       country: The Netherlands
       nuts1: NL3
       nuts2: NL31
   - NL321:
-      name: Kop van Noord-Holland
+      area_name: Kop van Noord-Holland
       country: The Netherlands
       nuts1: NL3
       nuts2: NL32
   - NL323:
-      name: IJmond
+      area_name: IJmond
       country: The Netherlands
       nuts1: NL3
       nuts2: NL32
   - NL324:
-      name: Agglomeratie Haarlem
+      area_name: Agglomeratie Haarlem
       country: The Netherlands
       nuts1: NL3
       nuts2: NL32
   - NL325:
-      name: Zaanstreek
+      area_name: Zaanstreek
       country: The Netherlands
       nuts1: NL3
       nuts2: NL32
   - NL327:
-      name: Het Gooi en Vechtstreek
+      area_name: Het Gooi en Vechtstreek
       country: The Netherlands
       nuts1: NL3
       nuts2: NL32
   - NL328:
-      name: Alkmaar en omgeving
+      area_name: Alkmaar en omgeving
       country: The Netherlands
       nuts1: NL3
       nuts2: NL32
   - NL329:
-      name: Groot-Amsterdam
+      area_name: Groot-Amsterdam
       country: The Netherlands
       nuts1: NL3
       nuts2: NL32
   - NL332:
-      name: Agglomeratie ’s-Gravenhage
+      area_name: Agglomeratie ’s-Gravenhage
       country: The Netherlands
       nuts1: NL3
       nuts2: NL33
   - NL333:
-      name: Delft en Westland
+      area_name: Delft en Westland
       country: The Netherlands
       nuts1: NL3
       nuts2: NL33
   - NL337:
-      name: Agglomeratie Leiden en Bollenstreek
+      area_name: Agglomeratie Leiden en Bollenstreek
       country: The Netherlands
       nuts1: NL3
       nuts2: NL33
   - NL33A:
-      name: Zuidoost-Zuid-Holland
+      area_name: Zuidoost-Zuid-Holland
       country: The Netherlands
       nuts1: NL3
       nuts2: NL33
   - NL33B:
-      name: Oost-Zuid-Holland
+      area_name: Oost-Zuid-Holland
       country: The Netherlands
       nuts1: NL3
       nuts2: NL33
   - NL33C:
-      name: Groot-Rijnmond
+      area_name: Groot-Rijnmond
       country: The Netherlands
       nuts1: NL3
       nuts2: NL33
   - NL341:
-      name: Zeeuwsch-Vlaanderen
+      area_name: Zeeuwsch-Vlaanderen
       country: The Netherlands
       nuts1: NL3
       nuts2: NL34
   - NL342:
-      name: Overig Zeeland
+      area_name: Overig Zeeland
       country: The Netherlands
       nuts1: NL3
       nuts2: NL34
   - NL411:
-      name: West-Noord-Brabant
+      area_name: West-Noord-Brabant
       country: The Netherlands
       nuts1: NL4
       nuts2: NL41
   - NL412:
-      name: Midden-Noord-Brabant
+      area_name: Midden-Noord-Brabant
       country: The Netherlands
       nuts1: NL4
       nuts2: NL41
   - NL413:
-      name: Noordoost-Noord-Brabant
+      area_name: Noordoost-Noord-Brabant
       country: The Netherlands
       nuts1: NL4
       nuts2: NL41
   - NL414:
-      name: Zuidoost-Noord-Brabant
+      area_name: Zuidoost-Noord-Brabant
       country: The Netherlands
       nuts1: NL4
       nuts2: NL41
   - NL421:
-      name: Noord-Limburg
+      area_name: Noord-Limburg
       country: The Netherlands
       nuts1: NL4
       nuts2: NL42
   - NL422:
-      name: Midden-Limburg
+      area_name: Midden-Limburg
       country: The Netherlands
       nuts1: NL4
       nuts2: NL42
   - NL423:
-      name: Zuid-Limburg
+      area_name: Zuid-Limburg
       country: The Netherlands
       nuts1: NL4
       nuts2: NL42
   - NLZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: The Netherlands
       nuts1: NLZ
       nuts2: NLZZ
   - AT111:
-      name: Mittelburgenland
+      area_name: Mittelburgenland
       country: Austria
       nuts1: AT1
       nuts2: AT11
   - AT112:
-      name: Nordburgenland
+      area_name: Nordburgenland
       country: Austria
       nuts1: AT1
       nuts2: AT11
   - AT113:
-      name: Südburgenland
+      area_name: Südburgenland
       country: Austria
       nuts1: AT1
       nuts2: AT11
   - AT121:
-      name: Mostviertel-Eisenwurzen
+      area_name: Mostviertel-Eisenwurzen
       country: Austria
       nuts1: AT1
       nuts2: AT12
   - AT122:
-      name: Niederösterreich-Süd
+      area_name: Niederösterreich-Süd
       country: Austria
       nuts1: AT1
       nuts2: AT12
   - AT123:
-      name: Sankt Pölten
+      area_name: Sankt Pölten
       country: Austria
       nuts1: AT1
       nuts2: AT12
   - AT124:
-      name: Waldviertel
+      area_name: Waldviertel
       country: Austria
       nuts1: AT1
       nuts2: AT12
   - AT125:
-      name: Weinviertel
+      area_name: Weinviertel
       country: Austria
       nuts1: AT1
       nuts2: AT12
   - AT126:
-      name: Wiener Umland/Nordteil
+      area_name: Wiener Umland/Nordteil
       country: Austria
       nuts1: AT1
       nuts2: AT12
   - AT127:
-      name: Wiener Umland/Südteil
+      area_name: Wiener Umland/Südteil
       country: Austria
       nuts1: AT1
       nuts2: AT12
   - AT130:
-      name: Wien
+      area_name: Wien
       country: Austria
       nuts1: AT1
       nuts2: AT13
   - AT211:
-      name: Klagenfurt-Villach
+      area_name: Klagenfurt-Villach
       country: Austria
       nuts1: AT2
       nuts2: AT21
   - AT212:
-      name: Oberkärnten
+      area_name: Oberkärnten
       country: Austria
       nuts1: AT2
       nuts2: AT21
   - AT213:
-      name: Unterkärnten
+      area_name: Unterkärnten
       country: Austria
       nuts1: AT2
       nuts2: AT21
   - AT221:
-      name: Graz
+      area_name: Graz
       country: Austria
       nuts1: AT2
       nuts2: AT22
   - AT222:
-      name: Liezen
+      area_name: Liezen
       country: Austria
       nuts1: AT2
       nuts2: AT22
   - AT223:
-      name: Östliche Obersteiermark
+      area_name: Östliche Obersteiermark
       country: Austria
       nuts1: AT2
       nuts2: AT22
   - AT224:
-      name: Oststeiermark
+      area_name: Oststeiermark
       country: Austria
       nuts1: AT2
       nuts2: AT22
   - AT225:
-      name: West- und Südsteiermark
+      area_name: West- und Südsteiermark
       country: Austria
       nuts1: AT2
       nuts2: AT22
   - AT226:
-      name: Westliche Obersteiermark
+      area_name: Westliche Obersteiermark
       country: Austria
       nuts1: AT2
       nuts2: AT22
   - AT311:
-      name: Innviertel
+      area_name: Innviertel
       country: Austria
       nuts1: AT3
       nuts2: AT31
   - AT312:
-      name: Linz-Wels
+      area_name: Linz-Wels
       country: Austria
       nuts1: AT3
       nuts2: AT31
   - AT313:
-      name: Mühlviertel
+      area_name: Mühlviertel
       country: Austria
       nuts1: AT3
       nuts2: AT31
   - AT314:
-      name: Steyr-Kirchdorf
+      area_name: Steyr-Kirchdorf
       country: Austria
       nuts1: AT3
       nuts2: AT31
   - AT315:
-      name: Traunviertel
+      area_name: Traunviertel
       country: Austria
       nuts1: AT3
       nuts2: AT31
   - AT321:
-      name: Lungau
+      area_name: Lungau
       country: Austria
       nuts1: AT3
       nuts2: AT32
   - AT322:
-      name: Pinzgau-Pongau
+      area_name: Pinzgau-Pongau
       country: Austria
       nuts1: AT3
       nuts2: AT32
   - AT323:
-      name: Salzburg und Umgebung
+      area_name: Salzburg und Umgebung
       country: Austria
       nuts1: AT3
       nuts2: AT32
   - AT331:
-      name: Außerfern
+      area_name: Außerfern
       country: Austria
       nuts1: AT3
       nuts2: AT33
   - AT332:
-      name: Innsbruck
+      area_name: Innsbruck
       country: Austria
       nuts1: AT3
       nuts2: AT33
   - AT333:
-      name: Osttirol
+      area_name: Osttirol
       country: Austria
       nuts1: AT3
       nuts2: AT33
   - AT334:
-      name: Tiroler Oberland
+      area_name: Tiroler Oberland
       country: Austria
       nuts1: AT3
       nuts2: AT33
   - AT335:
-      name: Tiroler Unterland
+      area_name: Tiroler Unterland
       country: Austria
       nuts1: AT3
       nuts2: AT33
   - AT341:
-      name: Bludenz-Bregenzer Wald
+      area_name: Bludenz-Bregenzer Wald
       country: Austria
       nuts1: AT3
       nuts2: AT34
   - AT342:
-      name: Rheintal-Bodenseegebiet
+      area_name: Rheintal-Bodenseegebiet
       country: Austria
       nuts1: AT3
       nuts2: AT34
   - ATZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Austria
       nuts1: ATZ
       nuts2: ATZZ
   - PL213:
-      name: Miasto Kraków
+      area_name: Miasto Kraków
       country: Poland
       nuts1: PL2
       nuts2: PL21
   - PL214:
-      name: Krakowski
+      area_name: Krakowski
       country: Poland
       nuts1: PL2
       nuts2: PL21
   - PL217:
-      name: Tarnowski
+      area_name: Tarnowski
       country: Poland
       nuts1: PL2
       nuts2: PL21
   - PL218:
-      name: Nowosądecki
+      area_name: Nowosądecki
       country: Poland
       nuts1: PL2
       nuts2: PL21
   - PL219:
-      name: Nowotarski
+      area_name: Nowotarski
       country: Poland
       nuts1: PL2
       nuts2: PL21
   - PL21A:
-      name: Oświęcimski
+      area_name: Oświęcimski
       country: Poland
       nuts1: PL2
       nuts2: PL21
   - PL224:
-      name: Częstochowski
+      area_name: Częstochowski
       country: Poland
       nuts1: PL2
       nuts2: PL22
   - PL225:
-      name: Bielski
+      area_name: Bielski
       country: Poland
       nuts1: PL2
       nuts2: PL22
   - PL227:
-      name: Rybnicki
+      area_name: Rybnicki
       country: Poland
       nuts1: PL2
       nuts2: PL22
   - PL228:
-      name: Bytomski
+      area_name: Bytomski
       country: Poland
       nuts1: PL2
       nuts2: PL22
   - PL229:
-      name: Gliwicki
+      area_name: Gliwicki
       country: Poland
       nuts1: PL2
       nuts2: PL22
   - PL22A:
-      name: Katowicki
+      area_name: Katowicki
       country: Poland
       nuts1: PL2
       nuts2: PL22
   - PL22B:
-      name: Sosnowiecki
+      area_name: Sosnowiecki
       country: Poland
       nuts1: PL2
       nuts2: PL22
   - PL22C:
-      name: Tyski
+      area_name: Tyski
       country: Poland
       nuts1: PL2
       nuts2: PL22
   - PL411:
-      name: Pilski
+      area_name: Pilski
       country: Poland
       nuts1: PL4
       nuts2: PL41
   - PL414:
-      name: Koniński
+      area_name: Koniński
       country: Poland
       nuts1: PL4
       nuts2: PL41
   - PL415:
-      name: Miasto Poznań
+      area_name: Miasto Poznań
       country: Poland
       nuts1: PL4
       nuts2: PL41
   - PL416:
-      name: Kaliski
+      area_name: Kaliski
       country: Poland
       nuts1: PL4
       nuts2: PL41
   - PL417:
-      name: Leszczyński
+      area_name: Leszczyński
       country: Poland
       nuts1: PL4
       nuts2: PL41
   - PL418:
-      name: Poznański
+      area_name: Poznański
       country: Poland
       nuts1: PL4
       nuts2: PL41
   - PL424:
-      name: Miasto Szczecin
+      area_name: Miasto Szczecin
       country: Poland
       nuts1: PL4
       nuts2: PL42
   - PL426:
-      name: Koszaliński
+      area_name: Koszaliński
       country: Poland
       nuts1: PL4
       nuts2: PL42
   - PL427:
-      name: Szczecinecko-pyrzycki
+      area_name: Szczecinecko-pyrzycki
       country: Poland
       nuts1: PL4
       nuts2: PL42
   - PL428:
-      name: Szczeciński
+      area_name: Szczeciński
       country: Poland
       nuts1: PL4
       nuts2: PL42
   - PL431:
-      name: Gorzowski
+      area_name: Gorzowski
       country: Poland
       nuts1: PL4
       nuts2: PL43
   - PL432:
-      name: Zielonogórski
+      area_name: Zielonogórski
       country: Poland
       nuts1: PL4
       nuts2: PL43
   - PL514:
-      name: Miasto Wrocław
+      area_name: Miasto Wrocław
       country: Poland
       nuts1: PL5
       nuts2: PL51
   - PL515:
-      name: Jeleniogórski
+      area_name: Jeleniogórski
       country: Poland
       nuts1: PL5
       nuts2: PL51
   - PL516:
-      name: Legnicko-głogowski
+      area_name: Legnicko-głogowski
       country: Poland
       nuts1: PL5
       nuts2: PL51
   - PL517:
-      name: Wałbrzyski
+      area_name: Wałbrzyski
       country: Poland
       nuts1: PL5
       nuts2: PL51
   - PL518:
-      name: Wrocławski
+      area_name: Wrocławski
       country: Poland
       nuts1: PL5
       nuts2: PL51
   - PL523:
-      name: Nyski
+      area_name: Nyski
       country: Poland
       nuts1: PL5
       nuts2: PL52
   - PL524:
-      name: Opolski
+      area_name: Opolski
       country: Poland
       nuts1: PL5
       nuts2: PL52
   - PL613:
-      name: Bydgosko-toruński
+      area_name: Bydgosko-toruński
       country: Poland
       nuts1: PL6
       nuts2: PL61
   - PL616:
-      name: Grudziądzki
+      area_name: Grudziądzki
       country: Poland
       nuts1: PL6
       nuts2: PL61
   - PL617:
-      name: Inowrocławski
+      area_name: Inowrocławski
       country: Poland
       nuts1: PL6
       nuts2: PL61
   - PL618:
-      name: Świecki
+      area_name: Świecki
       country: Poland
       nuts1: PL6
       nuts2: PL61
   - PL619:
-      name: Włocławski
+      area_name: Włocławski
       country: Poland
       nuts1: PL6
       nuts2: PL61
   - PL621:
-      name: Elbląski
+      area_name: Elbląski
       country: Poland
       nuts1: PL6
       nuts2: PL62
   - PL622:
-      name: Olsztyński
+      area_name: Olsztyński
       country: Poland
       nuts1: PL6
       nuts2: PL62
   - PL623:
-      name: Ełcki
+      area_name: Ełcki
       country: Poland
       nuts1: PL6
       nuts2: PL62
   - PL633:
-      name: Trójmiejski
+      area_name: Trójmiejski
       country: Poland
       nuts1: PL6
       nuts2: PL63
   - PL634:
-      name: Gdański
+      area_name: Gdański
       country: Poland
       nuts1: PL6
       nuts2: PL63
   - PL636:
-      name: Słupski
+      area_name: Słupski
       country: Poland
       nuts1: PL6
       nuts2: PL63
   - PL637:
-      name: Chojnicki
+      area_name: Chojnicki
       country: Poland
       nuts1: PL6
       nuts2: PL63
   - PL638:
-      name: Starogardzki
+      area_name: Starogardzki
       country: Poland
       nuts1: PL6
       nuts2: PL63
   - PL711:
-      name: Miasto Łódź
+      area_name: Miasto Łódź
       country: Poland
       nuts1: PL7
       nuts2: PL71
   - PL712:
-      name: Łódzki
+      area_name: Łódzki
       country: Poland
       nuts1: PL7
       nuts2: PL71
   - PL713:
-      name: Piotrkowski
+      area_name: Piotrkowski
       country: Poland
       nuts1: PL7
       nuts2: PL71
   - PL714:
-      name: Sieradzki
+      area_name: Sieradzki
       country: Poland
       nuts1: PL7
       nuts2: PL71
   - PL715:
-      name: Skierniewicki
+      area_name: Skierniewicki
       country: Poland
       nuts1: PL7
       nuts2: PL71
   - PL721:
-      name: Kielecki
+      area_name: Kielecki
       country: Poland
       nuts1: PL7
       nuts2: PL72
   - PL722:
-      name: Sandomiersko-jędrzejowski
+      area_name: Sandomiersko-jędrzejowski
       country: Poland
       nuts1: PL7
       nuts2: PL72
   - PL811:
-      name: Bialski
+      area_name: Bialski
       country: Poland
       nuts1: PL8
       nuts2: PL81
   - PL812:
-      name: Chełmsko-zamojski
+      area_name: Chełmsko-zamojski
       country: Poland
       nuts1: PL8
       nuts2: PL81
   - PL814:
-      name: Lubelski
+      area_name: Lubelski
       country: Poland
       nuts1: PL8
       nuts2: PL81
   - PL815:
-      name: Puławski
+      area_name: Puławski
       country: Poland
       nuts1: PL8
       nuts2: PL81
   - PL821:
-      name: Krośnieński
+      area_name: Krośnieński
       country: Poland
       nuts1: PL8
       nuts2: PL82
   - PL822:
-      name: Przemyski
+      area_name: Przemyski
       country: Poland
       nuts1: PL8
       nuts2: PL82
   - PL823:
-      name: Rzeszowski
+      area_name: Rzeszowski
       country: Poland
       nuts1: PL8
       nuts2: PL82
   - PL824:
-      name: Tarnobrzeski
+      area_name: Tarnobrzeski
       country: Poland
       nuts1: PL8
       nuts2: PL82
   - PL841:
-      name: Białostocki
+      area_name: Białostocki
       country: Poland
       nuts1: PL8
       nuts2: PL84
   - PL842:
-      name: Łomżyński
+      area_name: Łomżyński
       country: Poland
       nuts1: PL8
       nuts2: PL84
   - PL843:
-      name: Suwalski
+      area_name: Suwalski
       country: Poland
       nuts1: PL8
       nuts2: PL84
   - PL911:
-      name: Miasto Warszawa
+      area_name: Miasto Warszawa
       country: Poland
       nuts1: PL9
       nuts2: PL91
   - PL912:
-      name: Warszawski wschodni
+      area_name: Warszawski wschodni
       country: Poland
       nuts1: PL9
       nuts2: PL91
   - PL913:
-      name: Warszawski zachodni
+      area_name: Warszawski zachodni
       country: Poland
       nuts1: PL9
       nuts2: PL91
   - PL921:
-      name: Radomski
+      area_name: Radomski
       country: Poland
       nuts1: PL9
       nuts2: PL92
   - PL922:
-      name: Ciechanowski
+      area_name: Ciechanowski
       country: Poland
       nuts1: PL9
       nuts2: PL92
   - PL923:
-      name: Płocki
+      area_name: Płocki
       country: Poland
       nuts1: PL9
       nuts2: PL92
   - PL924:
-      name: Ostrołęcki
+      area_name: Ostrołęcki
       country: Poland
       nuts1: PL9
       nuts2: PL92
   - PL925:
-      name: Siedlecki
+      area_name: Siedlecki
       country: Poland
       nuts1: PL9
       nuts2: PL92
   - PL926:
-      name: Żyrardowski
+      area_name: Żyrardowski
       country: Poland
       nuts1: PL9
       nuts2: PL92
   - PLZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Poland
       nuts1: PLZ
       nuts2: PLZZ
   - PT111:
-      name: Alto Minho
+      area_name: Alto Minho
       country: Portugal
       nuts1: PT1
       nuts2: PT11
   - PT112:
-      name: Cávado
+      area_name: Cávado
       country: Portugal
       nuts1: PT1
       nuts2: PT11
   - PT119:
-      name: Ave
+      area_name: Ave
       country: Portugal
       nuts1: PT1
       nuts2: PT11
   - PT11A:
-      name: Área Metropolitana do Porto
+      area_name: Área Metropolitana do Porto
       country: Portugal
       nuts1: PT1
       nuts2: PT11
   - PT11B:
-      name: Alto Tâmega
+      area_name: Alto Tâmega
       country: Portugal
       nuts1: PT1
       nuts2: PT11
   - PT11C:
-      name: Tâmega e Sousa
+      area_name: Tâmega e Sousa
       country: Portugal
       nuts1: PT1
       nuts2: PT11
   - PT11D:
-      name: Douro
+      area_name: Douro
       country: Portugal
       nuts1: PT1
       nuts2: PT11
   - PT11E:
-      name: Terras de Trás-os-Montes
+      area_name: Terras de Trás-os-Montes
       country: Portugal
       nuts1: PT1
       nuts2: PT11
   - PT150:
-      name: Algarve
+      area_name: Algarve
       country: Portugal
       nuts1: PT1
       nuts2: PT15
   - PT16B:
-      name: Oeste
+      area_name: Oeste
       country: Portugal
       nuts1: PT1
       nuts2: PT16
   - PT16D:
-      name: Região de Aveiro
+      area_name: Região de Aveiro
       country: Portugal
       nuts1: PT1
       nuts2: PT16
   - PT16E:
-      name: Região de Coimbra
+      area_name: Região de Coimbra
       country: Portugal
       nuts1: PT1
       nuts2: PT16
   - PT16F:
-      name: Região de Leiria
+      area_name: Região de Leiria
       country: Portugal
       nuts1: PT1
       nuts2: PT16
   - PT16G:
-      name: Viseu Dão Lafões
+      area_name: Viseu Dão Lafões
       country: Portugal
       nuts1: PT1
       nuts2: PT16
   - PT16H:
-      name: Beira Baixa
+      area_name: Beira Baixa
       country: Portugal
       nuts1: PT1
       nuts2: PT16
   - PT16I:
-      name: Médio Tejo
+      area_name: Médio Tejo
       country: Portugal
       nuts1: PT1
       nuts2: PT16
   - PT16J:
-      name: Beiras e Serra da Estrela
+      area_name: Beiras e Serra da Estrela
       country: Portugal
       nuts1: PT1
       nuts2: PT16
   - PT170:
-      name: Área Metropolitana de Lisboa
+      area_name: Área Metropolitana de Lisboa
       country: Portugal
       nuts1: PT1
       nuts2: PT17
   - PT181:
-      name: Alentejo Litoral
+      area_name: Alentejo Litoral
       country: Portugal
       nuts1: PT1
       nuts2: PT18
   - PT184:
-      name: Baixo Alentejo
+      area_name: Baixo Alentejo
       country: Portugal
       nuts1: PT1
       nuts2: PT18
   - PT185:
-      name: Lezíria do Tejo
+      area_name: Lezíria do Tejo
       country: Portugal
       nuts1: PT1
       nuts2: PT18
   - PT186:
-      name: Alto Alentejo
+      area_name: Alto Alentejo
       country: Portugal
       nuts1: PT1
       nuts2: PT18
   - PT187:
-      name: Alentejo Central
+      area_name: Alentejo Central
       country: Portugal
       nuts1: PT1
       nuts2: PT18
   - PT200:
-      name: Região Autónoma dos Açores
+      area_name: Região Autónoma dos Açores
       country: Portugal
       nuts1: PT2
       nuts2: PT20
   - PT300:
-      name: Região Autónoma da Madeira
+      area_name: Região Autónoma da Madeira
       country: Portugal
       nuts1: PT3
       nuts2: PT30
   - PTZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Portugal
       nuts1: PTZ
       nuts2: PTZZ
   - RO111:
-      name: Bihor
+      area_name: Bihor
       country: Romania
       nuts1: RO1
       nuts2: RO11
   - RO112:
-      name: Bistriţa-Năsăud
+      area_name: Bistriţa-Năsăud
       country: Romania
       nuts1: RO1
       nuts2: RO11
   - RO113:
-      name: Cluj
+      area_name: Cluj
       country: Romania
       nuts1: RO1
       nuts2: RO11
   - RO114:
-      name: Maramureş
+      area_name: Maramureş
       country: Romania
       nuts1: RO1
       nuts2: RO11
   - RO115:
-      name: Satu Mare
+      area_name: Satu Mare
       country: Romania
       nuts1: RO1
       nuts2: RO11
   - RO116:
-      name: Sălaj
+      area_name: Sălaj
       country: Romania
       nuts1: RO1
       nuts2: RO11
   - RO121:
-      name: Alba
+      area_name: Alba
       country: Romania
       nuts1: RO1
       nuts2: RO12
   - RO122:
-      name: Braşov
+      area_name: Braşov
       country: Romania
       nuts1: RO1
       nuts2: RO12
   - RO123:
-      name: Covasna
+      area_name: Covasna
       country: Romania
       nuts1: RO1
       nuts2: RO12
   - RO124:
-      name: Harghita
+      area_name: Harghita
       country: Romania
       nuts1: RO1
       nuts2: RO12
   - RO125:
-      name: Mureş
+      area_name: Mureş
       country: Romania
       nuts1: RO1
       nuts2: RO12
   - RO126:
-      name: Sibiu
+      area_name: Sibiu
       country: Romania
       nuts1: RO1
       nuts2: RO12
   - RO211:
-      name: Bacău
+      area_name: Bacău
       country: Romania
       nuts1: RO2
       nuts2: RO21
   - RO212:
-      name: Botoşani
+      area_name: Botoşani
       country: Romania
       nuts1: RO2
       nuts2: RO21
   - RO213:
-      name: Iaşi
+      area_name: Iaşi
       country: Romania
       nuts1: RO2
       nuts2: RO21
   - RO214:
-      name: Neamţ
+      area_name: Neamţ
       country: Romania
       nuts1: RO2
       nuts2: RO21
   - RO215:
-      name: Suceava
+      area_name: Suceava
       country: Romania
       nuts1: RO2
       nuts2: RO21
   - RO216:
-      name: Vaslui
+      area_name: Vaslui
       country: Romania
       nuts1: RO2
       nuts2: RO21
   - RO221:
-      name: Brăila
+      area_name: Brăila
       country: Romania
       nuts1: RO2
       nuts2: RO22
   - RO222:
-      name: Buzău
+      area_name: Buzău
       country: Romania
       nuts1: RO2
       nuts2: RO22
   - RO223:
-      name: Constanţa
+      area_name: Constanţa
       country: Romania
       nuts1: RO2
       nuts2: RO22
   - RO224:
-      name: Galaţi
+      area_name: Galaţi
       country: Romania
       nuts1: RO2
       nuts2: RO22
   - RO225:
-      name: Tulcea
+      area_name: Tulcea
       country: Romania
       nuts1: RO2
       nuts2: RO22
   - RO226:
-      name: Vrancea
+      area_name: Vrancea
       country: Romania
       nuts1: RO2
       nuts2: RO22
   - RO311:
-      name: Argeş
+      area_name: Argeş
       country: Romania
       nuts1: RO3
       nuts2: RO31
   - RO312:
-      name: Călăraşi
+      area_name: Călăraşi
       country: Romania
       nuts1: RO3
       nuts2: RO31
   - RO313:
-      name: Dâmboviţa
+      area_name: Dâmboviţa
       country: Romania
       nuts1: RO3
       nuts2: RO31
   - RO314:
-      name: Giurgiu
+      area_name: Giurgiu
       country: Romania
       nuts1: RO3
       nuts2: RO31
   - RO315:
-      name: Ialomiţa
+      area_name: Ialomiţa
       country: Romania
       nuts1: RO3
       nuts2: RO31
   - RO316:
-      name: Prahova
+      area_name: Prahova
       country: Romania
       nuts1: RO3
       nuts2: RO31
   - RO317:
-      name: Teleorman
+      area_name: Teleorman
       country: Romania
       nuts1: RO3
       nuts2: RO31
   - RO321:
-      name: Bucureşti
+      area_name: Bucureşti
       country: Romania
       nuts1: RO3
       nuts2: RO32
   - RO322:
-      name: Ilfov
+      area_name: Ilfov
       country: Romania
       nuts1: RO322
       nuts2: RO32
   - RO411:
-      name: Dolj
+      area_name: Dolj
       country: Romania
       nuts1: RO4
       nuts2: RO41
   - RO412:
-      name: Gorj
+      area_name: Gorj
       country: Romania
       nuts1: RO4
       nuts2: RO41
   - RO413:
-      name: Mehedinţi
+      area_name: Mehedinţi
       country: Romania
       nuts1: RO4
       nuts2: RO41
   - RO414:
-      name: Olt
+      area_name: Olt
       country: Romania
       nuts1: RO4
       nuts2: RO41
   - RO415:
-      name: Vâlcea
+      area_name: Vâlcea
       country: Romania
       nuts1: RO4
       nuts2: RO41
   - RO421:
-      name: Arad
+      area_name: Arad
       country: Romania
       nuts1: RO4
       nuts2: RO42
   - RO422:
-      name: Caraş-Severin
+      area_name: Caraş-Severin
       country: Romania
       nuts1: RO4
       nuts2: RO42
   - RO423:
-      name: Hunedoara
+      area_name: Hunedoara
       country: Romania
       nuts1: RO4
       nuts2: RO42
   - RO424:
-      name: Timiş
+      area_name: Timiş
       country: Romania
       nuts1: RO4
       nuts2: RO42
   - ROZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Romania
       nuts1: ROZ
       nuts2: ROZZ
   - SI031:
-      name: Pomurska
+      area_name: Pomurska
       country: Slovenia
       nuts1: SI0
       nuts2: SI03
   - SI032:
-      name: Podravska
+      area_name: Podravska
       country: Slovenia
       nuts1: SI0
       nuts2: SI03
   - SI033:
-      name: Koroška
+      area_name: Koroška
       country: Slovenia
       nuts1: SI0
       nuts2: SI03
   - SI034:
-      name: Savinjska
+      area_name: Savinjska
       country: Slovenia
       nuts1: SI0
       nuts2: SI03
   - SI035:
-      name: Zasavska
+      area_name: Zasavska
       country: Slovenia
       nuts1: SI0
       nuts2: SI03
   - SI036:
-      name: Posavska
+      area_name: Posavska
       country: Slovenia
       nuts1: SI0
       nuts2: SI03
   - SI037:
-      name: Jugovzhodna Slovenija
+      area_name: Jugovzhodna Slovenija
       country: Slovenia
       nuts1: SI0
       nuts2: SI03
   - SI038:
-      name: Primorsko-notranjska
+      area_name: Primorsko-notranjska
       country: Slovenia
       nuts1: SI0
       nuts2: SI03
   - SI041:
-      name: Osrednjeslovenska
+      area_name: Osrednjeslovenska
       country: Slovenia
       nuts1: SI0
       nuts2: SI04
   - SI042:
-      name: Gorenjska
+      area_name: Gorenjska
       country: Slovenia
       nuts1: SI0
       nuts2: SI04
   - SI043:
-      name: Goriška
+      area_name: Goriška
       country: Slovenia
       nuts1: SI0
       nuts2: SI04
   - SI044:
-      name: Obalno-kraška
+      area_name: Obalno-kraška
       country: Slovenia
       nuts1: SI0
       nuts2: SI04
   - SIZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Slovenia
       nuts1: SIZ
       nuts2: SIZZ
   - SK010:
-      name: Bratislavský kraj
+      area_name: Bratislavský kraj
       country: Slovakia
       nuts1: SK0
       nuts2: SK01
   - SK021:
-      name: Trnavský kraj
+      area_name: Trnavský kraj
       country: Slovakia
       nuts1: SK0
       nuts2: SK02
   - SK022:
-      name: Trenčiansky kraj
+      area_name: Trenčiansky kraj
       country: Slovakia
       nuts1: SK0
       nuts2: SK02
   - SK023:
-      name: Nitriansky kraj
+      area_name: Nitriansky kraj
       country: Slovakia
       nuts1: SK0
       nuts2: SK02
   - SK031:
-      name: Žilinský kraj
+      area_name: Žilinský kraj
       country: Slovakia
       nuts1: SK0
       nuts2: SK03
   - SK032:
-      name: Banskobystrický kraj
+      area_name: Banskobystrický kraj
       country: Slovakia
       nuts1: SK0
       nuts2: SK03
   - SK041:
-      name: Prešovský kraj
+      area_name: Prešovský kraj
       country: Slovakia
       nuts1: SK0
       nuts2: SK04
   - SK042:
-      name: Košický kraj
+      area_name: Košický kraj
       country: Slovakia
       nuts1: SK0
       nuts2: SK04
   - SKZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Slovakia
       nuts1: SKZ
       nuts2: SKZZ
   - FI193:
-      name: Keski-Suomi
+      area_name: Keski-Suomi
       country: Finland
       nuts1: FI1
       nuts2: FI19
   - FI194:
-      name: Etelä-Pohjanmaa
+      area_name: Etelä-Pohjanmaa
       country: Finland
       nuts1: FI1
       nuts2: FI19
   - FI195:
-      name: Pohjanmaa
+      area_name: Pohjanmaa
       country: Finland
       nuts1: FI1
       nuts2: FI19
   - FI196:
-      name: Satakunta
+      area_name: Satakunta
       country: Finland
       nuts1: FI1
       nuts2: FI19
   - FI197:
-      name: Pirkanmaa
+      area_name: Pirkanmaa
       country: Finland
       nuts1: FI1
       nuts2: FI19
   - FI1B1:
-      name: Helsinki-Uusimaa
+      area_name: Helsinki-Uusimaa
       country: Finland
       nuts1: FI1
       nuts2: FI1B
   - FI1C1:
-      name: Varsinais-Suomi
+      area_name: Varsinais-Suomi
       country: Finland
       nuts1: FI1
       nuts2: FI1C
   - FI1C2:
-      name: Kanta-Häme
+      area_name: Kanta-Häme
       country: Finland
       nuts1: FI1
       nuts2: FI1C
   - FI1C3:
-      name: Päijät-Häme
+      area_name: Päijät-Häme
       country: Finland
       nuts1: FI1
       nuts2: FI1C
   - FI1C4:
-      name: Kymenlaakso
+      area_name: Kymenlaakso
       country: Finland
       nuts1: FI1
       nuts2: FI1C
   - FI1C5:
-      name: Etelä-Karjala
+      area_name: Etelä-Karjala
       country: Finland
       nuts1: FI1
       nuts2: FI1C
   - FI1D1:
-      name: Etelä-Savo
+      area_name: Etelä-Savo
       country: Finland
       nuts1: FI1
       nuts2: FI1D
   - FI1D2:
-      name: Pohjois-Savo
+      area_name: Pohjois-Savo
       country: Finland
       nuts1: FI1
       nuts2: FI1D
   - FI1D3:
-      name: Pohjois-Karjala
+      area_name: Pohjois-Karjala
       country: Finland
       nuts1: FI1
       nuts2: FI1D
   - FI1D5:
-      name: Keski-Pohjanmaa
+      area_name: Keski-Pohjanmaa
       country: Finland
       nuts1: FI1
       nuts2: FI1D
   - FI1D7:
-      name: Lappi
+      area_name: Lappi
       country: Finland
       nuts1: FI1
       nuts2: FI1D
   - FI1D8:
-      name: Kainuu
+      area_name: Kainuu
       country: Finland
       nuts1: FI1
       nuts2: FI1D
   - FI1D9:
-      name: Pohjois-Pohjanmaa
+      area_name: Pohjois-Pohjanmaa
       country: Finland
       nuts1: FI1
       nuts2: FI1D
   - FI200:
-      name: Åland
+      area_name: Åland
       country: Finland
       nuts1: FI2
       nuts2: FI20
   - FIZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Finland
       nuts1: FIZ
       nuts2: FIZZ
   - SE110:
-      name: Stockholms län
+      area_name: Stockholms län
       country: Sweden
       nuts1: SE1
       nuts2: SE11
   - SE121:
-      name: Uppsala län
+      area_name: Uppsala län
       country: Sweden
       nuts1: SE1
       nuts2: SE12
   - SE122:
-      name: Södermanlands län
+      area_name: Södermanlands län
       country: Sweden
       nuts1: SE1
       nuts2: SE12
   - SE123:
-      name: Östergötlands län
+      area_name: Östergötlands län
       country: Sweden
       nuts1: SE1
       nuts2: SE12
   - SE124:
-      name: Örebro län
+      area_name: Örebro län
       country: Sweden
       nuts1: SE1
       nuts2: SE12
   - SE125:
-      name: Västmanlands län
+      area_name: Västmanlands län
       country: Sweden
       nuts1: SE1
       nuts2: SE12
   - SE211:
-      name: Jönköpings län
+      area_name: Jönköpings län
       country: Sweden
       nuts1: SE2
       nuts2: SE21
   - SE212:
-      name: Kronobergs län
+      area_name: Kronobergs län
       country: Sweden
       nuts1: SE2
       nuts2: SE21
   - SE213:
-      name: Kalmar län
+      area_name: Kalmar län
       country: Sweden
       nuts1: SE2
       nuts2: SE21
   - SE214:
-      name: Gotlands län
+      area_name: Gotlands län
       country: Sweden
       nuts1: SE2
       nuts2: SE21
   - SE221:
-      name: Blekinge län
+      area_name: Blekinge län
       country: Sweden
       nuts1: SE2
       nuts2: SE22
   - SE224:
-      name: Skåne län
+      area_name: Skåne län
       country: Sweden
       nuts1: SE2
       nuts2: SE22
   - SE231:
-      name: Hallands län
+      area_name: Hallands län
       country: Sweden
       nuts1: SE2
       nuts2: SE23
   - SE232:
-      name: Västra Götalands län
+      area_name: Västra Götalands län
       country: Sweden
       nuts1: SE2
       nuts2: SE23
   - SE311:
-      name: Värmlands län
+      area_name: Värmlands län
       country: Sweden
       nuts1: SE3
       nuts2: SE31
   - SE312:
-      name: Dalarnas län
+      area_name: Dalarnas län
       country: Sweden
       nuts1: SE3
       nuts2: SE31
   - SE313:
-      name: Gävleborgs län
+      area_name: Gävleborgs län
       country: Sweden
       nuts1: SE3
       nuts2: SE31
   - SE321:
-      name: Västernorrlands län
+      area_name: Västernorrlands län
       country: Sweden
       nuts1: SE3
       nuts2: SE32
   - SE322:
-      name: Jämtlands län
+      area_name: Jämtlands län
       country: Sweden
       nuts1: SE3
       nuts2: SE32
   - SE331:
-      name: Västerbottens län
+      area_name: Västerbottens län
       country: Sweden
       nuts1: SE3
       nuts2: SE33
   - SE332:
-      name: Norrbottens län
+      area_name: Norrbottens län
       country: Sweden
       nuts1: SE3
       nuts2: SE33
   - SEZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Sweden
       nuts1: SEZ
       nuts2: SEZZ
   - UKC11:
-      name: Hartlepool and Stockton-on-Tees
+      area_name: Hartlepool and Stockton-on-Tees
       country: United Kingdom
       nuts1: UKC
       nuts2: UKC1
   - UKC12:
-      name: South Teesside
+      area_name: South Teesside
       country: United Kingdom
       nuts1: UKC
       nuts2: UKC1
   - UKC13:
-      name: Darlington
+      area_name: Darlington
       country: United Kingdom
       nuts1: UKC
       nuts2: UKC1
   - UKC14:
-      name: Durham CC
+      area_name: Durham CC
       country: United Kingdom
       nuts1: UKC
       nuts2: UKC1
   - UKC21:
-      name: Northumberland
+      area_name: Northumberland
       country: United Kingdom
       nuts1: UKC
       nuts2: UKC2
   - UKC22:
-      name: Tyneside
+      area_name: Tyneside
       country: United Kingdom
       nuts1: UKC
       nuts2: UKC2
   - UKC23:
-      name: Sunderland
+      area_name: Sunderland
       country: United Kingdom
       nuts1: UKC
       nuts2: UKC2
   - UKD11:
-      name: West Cumbria
+      area_name: West Cumbria
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD1
   - UKD12:
-      name: East Cumbria
+      area_name: East Cumbria
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD1
   - UKD33:
-      name: Manchester
+      area_name: Manchester
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD3
   - UKD34:
-      name: Greater Manchester South West
+      area_name: Greater Manchester South West
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD3
   - UKD35:
-      name: Greater Manchester South East
+      area_name: Greater Manchester South East
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD3
   - UKD36:
-      name: Greater Manchester North West
+      area_name: Greater Manchester North West
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD3
   - UKD37:
-      name: Greater Manchester North East
+      area_name: Greater Manchester North East
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD3
   - UKD41:
-      name: Blackburn with Darwen
+      area_name: Blackburn with Darwen
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD4
   - UKD42:
-      name: Blackpool
+      area_name: Blackpool
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD4
   - UKD44:
-      name: Lancaster and Wyre
+      area_name: Lancaster and Wyre
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD4
   - UKD45:
-      name: Mid Lancashire
+      area_name: Mid Lancashire
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD4
   - UKD46:
-      name: East Lancashire
+      area_name: East Lancashire
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD4
   - UKD47:
-      name: Chorley and West Lancashire
+      area_name: Chorley and West Lancashire
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD4
   - UKD61:
-      name: Warrington
+      area_name: Warrington
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD6
   - UKD62:
-      name: Cheshire East
+      area_name: Cheshire East
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD6
   - UKD63:
-      name: Cheshire West and Chester
+      area_name: Cheshire West and Chester
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD6
   - UKD71:
-      name: East Merseyside
+      area_name: East Merseyside
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD7
   - UKD72:
-      name: Liverpool
+      area_name: Liverpool
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD7
   - UKD73:
-      name: Sefton
+      area_name: Sefton
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD7
   - UKD74:
-      name: Wirral
+      area_name: Wirral
       country: United Kingdom
       nuts1: UKD
       nuts2: UKD7
   - UKE11:
-      name: Kingston upon Hull, City of
+      area_name: Kingston upon Hull, City of
       country: United Kingdom
       nuts1: UKE
       nuts2: UKE1
   - UKE12:
-      name: East Riding of Yorkshire
+      area_name: East Riding of Yorkshire
       country: United Kingdom
       nuts1: UKE
       nuts2: UKE1
   - UKE13:
-      name: North and North East Lincolnshire
+      area_name: North and North East Lincolnshire
       country: United Kingdom
       nuts1: UKE
       nuts2: UKE1
   - UKE21:
-      name: York
+      area_name: York
       country: United Kingdom
       nuts1: UKE
       nuts2: UKE2
   - UKE22:
-      name: North Yorkshire CC
+      area_name: North Yorkshire CC
       country: United Kingdom
       nuts1: UKE
       nuts2: UKE2
   - UKE31:
-      name: Barnsley, Doncaster and Rotherham
+      area_name: Barnsley, Doncaster and Rotherham
       country: United Kingdom
       nuts1: UKE
       nuts2: UKE3
   - UKE32:
-      name: Sheffield
+      area_name: Sheffield
       country: United Kingdom
       nuts1: UKE
       nuts2: UKE3
   - UKE41:
-      name: Bradford
+      area_name: Bradford
       country: United Kingdom
       nuts1: UKE
       nuts2: UKE4
   - UKE42:
-      name: Leeds
+      area_name: Leeds
       country: United Kingdom
       nuts1: UKE
       nuts2: UKE4
   - UKE44:
-      name: Calderdale and Kirklees
+      area_name: Calderdale and Kirklees
       country: United Kingdom
       nuts1: UKE
       nuts2: UKE4
   - UKE45:
-      name: Wakefield
+      area_name: Wakefield
       country: United Kingdom
       nuts1: UKE
       nuts2: UKE4
   - UKF11:
-      name: Derby
+      area_name: Derby
       country: United Kingdom
       nuts1: UKF
       nuts2: UKF1
   - UKF12:
-      name: East Derbyshire
+      area_name: East Derbyshire
       country: United Kingdom
       nuts1: UKF
       nuts2: UKF1
   - UKF13:
-      name: South and West Derbyshire
+      area_name: South and West Derbyshire
       country: United Kingdom
       nuts1: UKF
       nuts2: UKF1
   - UKF14:
-      name: Nottingham
+      area_name: Nottingham
       country: United Kingdom
       nuts1: UKF
       nuts2: UKF1
   - UKF15:
-      name: North Nottinghamshire
+      area_name: North Nottinghamshire
       country: United Kingdom
       nuts1: UKF
       nuts2: UKF1
   - UKF16:
-      name: South Nottinghamshire
+      area_name: South Nottinghamshire
       country: United Kingdom
       nuts1: UKF
       nuts2: UKF1
   - UKF21:
-      name: Leicester
+      area_name: Leicester
       country: United Kingdom
       nuts1: UKF
       nuts2: UKF2
   - UKF22:
-      name: Leicestershire CC and Rutland
+      area_name: Leicestershire CC and Rutland
       country: United Kingdom
       nuts1: UKF
       nuts2: UKF2
   - UKF24:
-      name: West Northamptonshire
+      area_name: West Northamptonshire
       country: United Kingdom
       nuts1: UKF
       nuts2: UKF2
   - UKF25:
-      name: North Northamptonshire
+      area_name: North Northamptonshire
       country: United Kingdom
       nuts1: UKF
       nuts2: UKF2
   - UKF30:
-      name: Lincolnshire
+      area_name: Lincolnshire
       country: United Kingdom
       nuts1: UKF
       nuts2: UKF3
   - UKG11:
-      name: Herefordshire, County of
+      area_name: Herefordshire, County of
       country: United Kingdom
       nuts1: UKG
       nuts2: UKG1
   - UKG12:
-      name: Worcestershire
+      area_name: Worcestershire
       country: United Kingdom
       nuts1: UKG
       nuts2: UKG1
   - UKG13:
-      name: Warwickshire
+      area_name: Warwickshire
       country: United Kingdom
       nuts1: UKG
       nuts2: UKG1
   - UKG21:
-      name: Telford and Wrekin
+      area_name: Telford and Wrekin
       country: United Kingdom
       nuts1: UKG
       nuts2: UKG2
   - UKG22:
-      name: Shropshire CC
+      area_name: Shropshire CC
       country: United Kingdom
       nuts1: UKG
       nuts2: UKG2
   - UKG23:
-      name: Stoke-on-Trent
+      area_name: Stoke-on-Trent
       country: United Kingdom
       nuts1: UKG
       nuts2: UKG2
   - UKG24:
-      name: Staffordshire CC
+      area_name: Staffordshire CC
       country: United Kingdom
       nuts1: UKG
       nuts2: UKG2
   - UKG31:
-      name: Birmingham
+      area_name: Birmingham
       country: United Kingdom
       nuts1: UKG
       nuts2: UKG3
   - UKG32:
-      name: Solihull
+      area_name: Solihull
       country: United Kingdom
       nuts1: UKG
       nuts2: UKG3
   - UKG33:
-      name: Coventry
+      area_name: Coventry
       country: United Kingdom
       nuts1: UKG
       nuts2: UKG3
   - UKG36:
-      name: Dudley
+      area_name: Dudley
       country: United Kingdom
       nuts1: UKG
       nuts2: UKG3
   - UKG37:
-      name: Sandwell
+      area_name: Sandwell
       country: United Kingdom
       nuts1: UKG
       nuts2: UKG3
   - UKG38:
-      name: Walsall
+      area_name: Walsall
       country: United Kingdom
       nuts1: UKG
       nuts2: UKG3
   - UKG39:
-      name: Wolverhampton
+      area_name: Wolverhampton
       country: United Kingdom
       nuts1: UKG
       nuts2: UKG3
   - UKH11:
-      name: Peterborough
+      area_name: Peterborough
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH1
   - UKH12:
-      name: Cambridgeshire CC
+      area_name: Cambridgeshire CC
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH1
   - UKH14:
-      name: Suffolk
+      area_name: Suffolk
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH1
   - UKH15:
-      name: Norwich and East Norfolk
+      area_name: Norwich and East Norfolk
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH1
   - UKH16:
-      name: North and West Norfolk
+      area_name: North and West Norfolk
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH1
   - UKH17:
-      name: Breckland and South Norfolk
+      area_name: Breckland and South Norfolk
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH1
   - UKH21:
-      name: Luton
+      area_name: Luton
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH2
   - UKH23:
-      name: Hertfordshire
+      area_name: Hertfordshire
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH2
   - UKH24:
-      name: Bedford
+      area_name: Bedford
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH2
   - UKH25:
-      name: Central Bedfordshire
+      area_name: Central Bedfordshire
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH2
   - UKH31:
-      name: Southend-on-Sea
+      area_name: Southend-on-Sea
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH3
   - UKH32:
-      name: Thurrock
+      area_name: Thurrock
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH3
   - UKH34:
-      name: Essex Haven Gateway
+      area_name: Essex Haven Gateway
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH3
   - UKH35:
-      name: West Essex
+      area_name: West Essex
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH3
   - UKH36:
-      name: Heart of Essex
+      area_name: Heart of Essex
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH3
   - UKH37:
-      name: Essex Thames Gateway
+      area_name: Essex Thames Gateway
       country: United Kingdom
       nuts1: UKH
       nuts2: UKH3
   - UKI31:
-      name: Camden and City of London
+      area_name: Camden and City of London
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI3
   - UKI32:
-      name: Westminster
+      area_name: Westminster
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI3
   - UKI33:
-      name: Kensington & Chelsea and Hammersmith & Fulham
+      area_name: Kensington & Chelsea and Hammersmith & Fulham
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI3
   - UKI34:
-      name: Wandsworth
+      area_name: Wandsworth
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI3
   - UKI41:
-      name: Hackney and Newham
+      area_name: Hackney and Newham
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI4
   - UKI42:
-      name: Tower Hamlets
+      area_name: Tower Hamlets
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI4
   - UKI43:
-      name: Haringey and Islington
+      area_name: Haringey and Islington
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI4
   - UKI44:
-      name: Lewisham and Southwark
+      area_name: Lewisham and Southwark
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI4
   - UKI45:
-      name: Lambeth
+      area_name: Lambeth
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI4
   - UKI51:
-      name: Bexley and Greenwich
+      area_name: Bexley and Greenwich
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI5
   - UKI52:
-      name: Barking & Dagenham and Havering
+      area_name: Barking & Dagenham and Havering
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI5
   - UKI53:
-      name: Redbridge and Waltham Forest
+      area_name: Redbridge and Waltham Forest
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI5
   - UKI54:
-      name: Enfield
+      area_name: Enfield
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI5
   - UKI61:
-      name: Bromley
+      area_name: Bromley
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI6
   - UKI62:
-      name: Croydon
+      area_name: Croydon
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI6
   - UKI63:
-      name: Merton, Kingston upon Thames and Sutton
+      area_name: Merton, Kingston upon Thames and Sutton
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI6
   - UKI71:
-      name: Barnet
+      area_name: Barnet
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI7
   - UKI72:
-      name: Brent
+      area_name: Brent
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI7
   - UKI73:
-      name: Ealing
+      area_name: Ealing
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI7
   - UKI74:
-      name: Harrow and Hillingdon
+      area_name: Harrow and Hillingdon
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI7
   - UKI75:
-      name: Hounslow and Richmond upon Thames
+      area_name: Hounslow and Richmond upon Thames
       country: United Kingdom
       nuts1: UKI
       nuts2: UKI7
   - UKJ11:
-      name: Berkshire
+      area_name: Berkshire
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ1
   - UKJ12:
-      name: Milton Keynes
+      area_name: Milton Keynes
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ1
   - UKJ13:
-      name: Buckinghamshire CC
+      area_name: Buckinghamshire CC
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ1
   - UKJ14:
-      name: Oxfordshire
+      area_name: Oxfordshire
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ1
   - UKJ21:
-      name: Brighton and Hove
+      area_name: Brighton and Hove
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ2
   - UKJ22:
-      name: East Sussex CC
+      area_name: East Sussex CC
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ2
   - UKJ25:
-      name: West Surrey
+      area_name: West Surrey
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ2
   - UKJ26:
-      name: East Surrey
+      area_name: East Surrey
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ2
   - UKJ27:
-      name: West Sussex (South West)
+      area_name: West Sussex (South West)
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ2
   - UKJ28:
-      name: West Sussex (North East)
+      area_name: West Sussex (North East)
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ2
   - UKJ31:
-      name: Portsmouth
+      area_name: Portsmouth
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ3
   - UKJ32:
-      name: Southampton
+      area_name: Southampton
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ3
   - UKJ34:
-      name: Isle of Wight
+      area_name: Isle of Wight
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ3
   - UKJ35:
-      name: South Hampshire
+      area_name: South Hampshire
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ3
   - UKJ36:
-      name: Central Hampshire
+      area_name: Central Hampshire
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ3
   - UKJ37:
-      name: North Hampshire
+      area_name: North Hampshire
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ3
   - UKJ41:
-      name: Medway
+      area_name: Medway
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ4
   - UKJ43:
-      name: Kent Thames Gateway
+      area_name: Kent Thames Gateway
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ4
   - UKJ44:
-      name: East Kent
+      area_name: East Kent
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ4
   - UKJ45:
-      name: Mid Kent
+      area_name: Mid Kent
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ4
   - UKJ46:
-      name: West Kent
+      area_name: West Kent
       country: United Kingdom
       nuts1: UKJ
       nuts2: UKJ4
   - UKK11:
-      name: Bristol, City of
+      area_name: Bristol, City of
       country: United Kingdom
       nuts1: UKK
       nuts2: UKK1
   - UKK12:
-      name: Bath and North East Somerset, North Somerset and South Gloucestershire
+      area_name: Bath and North East Somerset, North Somerset and South Gloucestershire
       country: United Kingdom
       nuts1: UKK
       nuts2: UKK1
   - UKK13:
-      name: Gloucestershire
+      area_name: Gloucestershire
       country: United Kingdom
       nuts1: UKK
       nuts2: UKK1
   - UKK14:
-      name: Swindon
+      area_name: Swindon
       country: United Kingdom
       nuts1: UKK
       nuts2: UKK1
   - UKK15:
-      name: Wiltshire CC
+      area_name: Wiltshire CC
       country: United Kingdom
       nuts1: UKK
       nuts2: UKK1
   - UKK23:
-      name: Somerset
+      area_name: Somerset
       country: United Kingdom
       nuts1: UKK
       nuts2: UKK2
   - UKK24:
-      name: Bournemouth, Christchurch and Poole
+      area_name: Bournemouth, Christchurch and Poole
       country: United Kingdom
       nuts1: UKK
       nuts2: UKK2
   - UKK25:
-      name: Dorset
+      area_name: Dorset
       country: United Kingdom
       nuts1: UKK
       nuts2: UKK2
   - UKK30:
-      name: Cornwall and Isles of Scilly
+      area_name: Cornwall and Isles of Scilly
       country: United Kingdom
       nuts1: UKK
       nuts2: UKK3
   - UKK41:
-      name: Plymouth
+      area_name: Plymouth
       country: United Kingdom
       nuts1: UKK
       nuts2: UKK4
   - UKK42:
-      name: Torbay
+      area_name: Torbay
       country: United Kingdom
       nuts1: UKK
       nuts2: UKK4
   - UKK43:
-      name: Devon CC
+      area_name: Devon CC
       country: United Kingdom
       nuts1: UKK
       nuts2: UKK4
   - UKL11:
-      name: Isle of Anglesey
+      area_name: Isle of Anglesey
       country: United Kingdom
       nuts1: UKL
       nuts2: UKL1
   - UKL12:
-      name: Gwynedd
+      area_name: Gwynedd
       country: United Kingdom
       nuts1: UKL
       nuts2: UKL1
   - UKL13:
-      name: Conwy and Denbighshire
+      area_name: Conwy and Denbighshire
       country: United Kingdom
       nuts1: UKL
       nuts2: UKL1
   - UKL14:
-      name: South West Wales
+      area_name: South West Wales
       country: United Kingdom
       nuts1: UKL
       nuts2: UKL1
   - UKL15:
-      name: Central Valleys
+      area_name: Central Valleys
       country: United Kingdom
       nuts1: UKL
       nuts2: UKL1
   - UKL16:
-      name: Gwent Valleys
+      area_name: Gwent Valleys
       country: United Kingdom
       nuts1: UKL
       nuts2: UKL1
   - UKL17:
-      name: Bridgend and Neath Port Talbot
+      area_name: Bridgend and Neath Port Talbot
       country: United Kingdom
       nuts1: UKL
       nuts2: UKL1
   - UKL18:
-      name: Swansea
+      area_name: Swansea
       country: United Kingdom
       nuts1: UKL
       nuts2: UKL1
   - UKL21:
-      name: Monmouthshire and Newport
+      area_name: Monmouthshire and Newport
       country: United Kingdom
       nuts1: UKL
       nuts2: UKL2
   - UKL22:
-      name: Cardiff and Vale of Glamorgan
+      area_name: Cardiff and Vale of Glamorgan
       country: United Kingdom
       nuts1: UKL
       nuts2: UKL2
   - UKL23:
-      name: Flintshire and Wrexham
+      area_name: Flintshire and Wrexham
       country: United Kingdom
       nuts1: UKL
       nuts2: UKL2
   - UKL24:
-      name: Powys
+      area_name: Powys
       country: United Kingdom
       nuts1: UKL
       nuts2: UKL2
   - UKM50:
-      name: Aberdeen City and Aberdeenshire
+      area_name: Aberdeen City and Aberdeenshire
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM5
   - UKM61:
-      name: Caithness & Sutherland and Ross & Cromarty
+      area_name: Caithness & Sutherland and Ross & Cromarty
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM6
   - UKM62:
-      name: Inverness & Nairn and Moray, Badenoch & Strathspey
+      area_name: Inverness & Nairn and Moray, Badenoch & Strathspey
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM6
   - UKM63:
-      name: Lochaber, Skye & Lochalsh, Arran & Cumbrae and Argyll & Bute
+      area_name: Lochaber, Skye & Lochalsh, Arran & Cumbrae and Argyll & Bute
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM6
   - UKM64:
-      name: Na h-Eileanan Siar (Western Isles)
+      area_name: Na h-Eileanan Siar (Western Isles)
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM6
   - UKM65:
-      name: Orkney Islands
+      area_name: Orkney Islands
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM6
   - UKM66:
-      name: Shetland Islands
+      area_name: Shetland Islands
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM6
   - UKM71:
-      name: Angus and Dundee City
+      area_name: Angus and Dundee City
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM7
   - UKM72:
-      name: Clackmannanshire and Fife
+      area_name: Clackmannanshire and Fife
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM7
   - UKM73:
-      name: East Lothian and Midlothian
+      area_name: East Lothian and Midlothian
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM7
   - UKM75:
-      name: Edinburgh, City of
+      area_name: Edinburgh, City of
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM7
   - UKM76:
-      name: Falkirk
+      area_name: Falkirk
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM7
   - UKM77:
-      name: Perth & Kinross and Stirling
+      area_name: Perth & Kinross and Stirling
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM7
   - UKM78:
-      name: West Lothian
+      area_name: West Lothian
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM7
   - UKM81:
-      name: East Dunbartonshire, West Dunbartonshire and Helensburgh & Lomond
+      area_name: East Dunbartonshire, West Dunbartonshire and Helensburgh & Lomond
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM8
   - UKM82:
-      name: Glasgow City
+      area_name: Glasgow City
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM8
   - UKM83:
-      name: Inverclyde, East Renfrewshire and Renfrewshire
+      area_name: Inverclyde, East Renfrewshire and Renfrewshire
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM8
   - UKM84:
-      name: North Lanarkshire
+      area_name: North Lanarkshire
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM8
   - UKM91:
-      name: Scottish Borders
+      area_name: Scottish Borders
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM9
   - UKM92:
-      name: Dumfries & Galloway
+      area_name: Dumfries & Galloway
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM9
   - UKM93:
-      name: East Ayrshire and North Ayrshire mainland
+      area_name: East Ayrshire and North Ayrshire mainland
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM9
   - UKM94:
-      name: South Ayrshire
+      area_name: South Ayrshire
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM9
   - UKM95:
-      name: South Lanarkshire
+      area_name: South Lanarkshire
       country: United Kingdom
       nuts1: UKM
       nuts2: UKM9
   - UKN06:
-      name: Belfast
+      area_name: Belfast
       country: United Kingdom
       nuts1: UKN
       nuts2: UKN0
   - UKN07:
-      name: Armagh City, Banbridge and Craigavon
+      area_name: Armagh City, Banbridge and Craigavon
       country: United Kingdom
       nuts1: UKN
       nuts2: UKN0
   - UKN08:
-      name: Newry, Mourne and Down
+      area_name: Newry, Mourne and Down
       country: United Kingdom
       nuts1: UKN
       nuts2: UKN0
   - UKN09:
-      name: Ards and North Down 
+      area_name: Ards and North Down 
       country: United Kingdom
       nuts1: UKN
       nuts2: UKN0
   - UKN0A:
-      name: Derry City and Strabane
+      area_name: Derry City and Strabane
       country: United Kingdom
       nuts1: UKN
       nuts2: UKN0
   - UKN0B:
-      name: Mid Ulster
+      area_name: Mid Ulster
       country: United Kingdom
       nuts1: UKN
       nuts2: UKN0
   - UKN0C:
-      name: Causeway Coast and Glens
+      area_name: Causeway Coast and Glens
       country: United Kingdom
       nuts1: UKN
       nuts2: UKN0
   - UKN0D:
-      name: Antrim and Newtownabbey
+      area_name: Antrim and Newtownabbey
       country: United Kingdom
       nuts1: UKN
       nuts2: UKN0
   - UKN0E:
-      name: Lisburn and Castlereagh
+      area_name: Lisburn and Castlereagh
       country: United Kingdom
       nuts1: UKN
       nuts2: UKN0
   - UKN0F:
-      name: Mid and East Antrim
+      area_name: Mid and East Antrim
       country: United Kingdom
       nuts1: UKN
       nuts2: UKN0
   - UKN0G:
-      name: Fermanagh and Omagh
+      area_name: Fermanagh and Omagh
       country: United Kingdom
       nuts1: UKN
       nuts2: UKN0
   - UKZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: United Kingdom
       nuts1: UKZ
       nuts2: UKZZ
   - IS001:
-      name: Höfuðborgarsvæði
+      area_name: Höfuðborgarsvæði
       country: Iceland
       nuts1: IS0
       nuts2: IS00
   - IS002:
-      name: Landsbyggð
+      area_name: Landsbyggð
       country: Iceland
       nuts1: IS0
       nuts2: IS00
   - ISZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Iceland
       nuts1: ISZ
       nuts2: ISZZ
   - LI000:
-      name: Liechtenstein
+      area_name: Liechtenstein
       country: Liechtenstein
       nuts1: LI0
       nuts2: LI00
   - LIZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Liechtenstein
       nuts1: LIZ
       nuts2: LIZZ
   - NO020:
-      name: Innlandet
+      area_name: Innlandet
       country: Norway
       nuts1: NO0
       nuts2: NO02
   - NO060:
-      name: Trøndelag
+      area_name: Trøndelag
       country: Norway
       nuts1: NO0
       nuts2: NO06
   - NO071:
-      name: Nordland
+      area_name: Nordland
       country: Norway
       nuts1: NO0
       nuts2: NO07
   - NO074:
-      name: Troms og Finnmark
+      area_name: Troms og Finnmark
       country: Norway
       nuts1: NO0
       nuts2: NO07
   - NO081:
-      name: Oslo
+      area_name: Oslo
       country: Norway
       nuts1: NO0
       nuts2: NO08
   - NO082:
-      name: Viken
+      area_name: Viken
       country: Norway
       nuts1: NO0
       nuts2: NO08
   - NO091:
-      name: Vestfold og Telemark
+      area_name: Vestfold og Telemark
       country: Norway
       nuts1: NO0
       nuts2: NO09
   - NO092:
-      name: Agder
+      area_name: Agder
       country: Norway
       nuts1: NO0
       nuts2: NO09
   - NO0A1:
-      name: Rogaland
+      area_name: Rogaland
       country: Norway
       nuts1: NO0
       nuts2: NO0A
   - NO0A2:
-      name: Vestland
+      area_name: Vestland
       country: Norway
       nuts1: NO0
       nuts2: NO0A
   - NO0A3:
-      name: Møre og Romsdal
+      area_name: Møre og Romsdal
       country: Norway
       nuts1: NO0
       nuts2: NO0A
   - NO0B1:
-      name: Jan Mayen
+      area_name: Jan Mayen
       country: Norway
       nuts1: NO0
       nuts2: NO0B
   - NO0B2:
-      name: Svalbard
+      area_name: Svalbard
       country: Norway
       nuts1: NO0
       nuts2: NO0B
   - NOZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Norway
       nuts1: NOZ
       nuts2: NOZZ
   - CH011:
-      name: Vaud
+      area_name: Vaud
       country: Switzerland
       nuts1: CH0
       nuts2: CH01
   - CH012:
-      name: Valais / Wallis
+      area_name: Valais / Wallis
       country: Switzerland
       nuts1: CH0
       nuts2: CH01
   - CH013:
-      name: Genève
+      area_name: Genève
       country: Switzerland
       nuts1: CH0
       nuts2: CH01
   - CH021:
-      name: Bern / Berne
+      area_name: Bern / Berne
       country: Switzerland
       nuts1: CH0
       nuts2: CH02
   - CH022:
-      name: Fribourg / Freiburg
+      area_name: Fribourg / Freiburg
       country: Switzerland
       nuts1: CH0
       nuts2: CH02
   - CH023:
-      name: Solothurn
+      area_name: Solothurn
       country: Switzerland
       nuts1: CH0
       nuts2: CH02
   - CH024:
-      name: Neuchâtel
+      area_name: Neuchâtel
       country: Switzerland
       nuts1: CH0
       nuts2: CH02
   - CH025:
-      name: Jura
+      area_name: Jura
       country: Switzerland
       nuts1: CH0
       nuts2: CH02
   - CH031:
-      name: Basel-Stadt
+      area_name: Basel-Stadt
       country: Switzerland
       nuts1: CH0
       nuts2: CH03
   - CH032:
-      name: Basel-Landschaft
+      area_name: Basel-Landschaft
       country: Switzerland
       nuts1: CH0
       nuts2: CH03
   - CH033:
-      name: Aargau
+      area_name: Aargau
       country: Switzerland
       nuts1: CH0
       nuts2: CH03
   - CH040:
-      name: Zürich
+      area_name: Zürich
       country: Switzerland
       nuts1: CH0
       nuts2: CH04
   - CH051:
-      name: Glarus
+      area_name: Glarus
       country: Switzerland
       nuts1: CH0
       nuts2: CH05
   - CH052:
-      name: Schaffhausen
+      area_name: Schaffhausen
       country: Switzerland
       nuts1: CH0
       nuts2: CH05
   - CH053:
-      name: Appenzell Ausserrhoden
+      area_name: Appenzell Ausserrhoden
       country: Switzerland
       nuts1: CH0
       nuts2: CH05
   - CH054:
-      name: Appenzell Innerrhoden
+      area_name: Appenzell Innerrhoden
       country: Switzerland
       nuts1: CH0
       nuts2: CH05
   - CH055:
-      name: St. Gallen
+      area_name: St. Gallen
       country: Switzerland
       nuts1: CH0
       nuts2: CH05
   - CH056:
-      name: Graubünden / Grigioni / Grischun
+      area_name: Graubünden / Grigioni / Grischun
       country: Switzerland
       nuts1: CH0
       nuts2: CH05
   - CH057:
-      name: Thurgau
+      area_name: Thurgau
       country: Switzerland
       nuts1: CH0
       nuts2: CH05
   - CH061:
-      name: Luzern
+      area_name: Luzern
       country: Switzerland
       nuts1: CH0
       nuts2: CH06
   - CH062:
-      name: Uri
+      area_name: Uri
       country: Switzerland
       nuts1: CH0
       nuts2: CH06
   - CH063:
-      name: Schwyz
+      area_name: Schwyz
       country: Switzerland
       nuts1: CH0
       nuts2: CH06
   - CH064:
-      name: Obwalden
+      area_name: Obwalden
       country: Switzerland
       nuts1: CH0
       nuts2: CH06
   - CH065:
-      name: Nidwalden
+      area_name: Nidwalden
       country: Switzerland
       nuts1: CH0
       nuts2: CH06
   - CH066:
-      name: Zug
+      area_name: Zug
       country: Switzerland
       nuts1: CH0
       nuts2: CH06
   - CH070:
-      name: Ticino
+      area_name: Ticino
       country: Switzerland
       nuts1: CH0
       nuts2: CH07
   - CHZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Switzerland
       nuts1: CHZ
       nuts2: CHZZ
   - ME000:
-      name: Црна Гора
+      area_name: Црна Гора
       country: Montenegro
       nuts1: ME0
       nuts2: ME00
   - MEZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Montenegro
       nuts1: MEZ
       nuts2: MEZZ
   - MK001:
-      name: Вардарски
+      area_name: Вардарски
       country: North Macedonia
       nuts1: MK0
       nuts2: MK00
   - MK002:
-      name: Источен
+      area_name: Источен
       country: North Macedonia
       nuts1: MK0
       nuts2: MK00
   - MK003:
-      name: Југозападен
+      area_name: Југозападен
       country: North Macedonia
       nuts1: MK0
       nuts2: MK00
   - MK004:
-      name: Југоисточен
+      area_name: Југоисточен
       country: North Macedonia
       nuts1: MK0
       nuts2: MK00
   - MK005:
-      name: Пелагониски
+      area_name: Пелагониски
       country: North Macedonia
       nuts1: MK0
       nuts2: MK00
   - MK006:
-      name: Полошки
+      area_name: Полошки
       country: North Macedonia
       nuts1: MK0
       nuts2: MK00
   - MK007:
-      name: Североисточен
+      area_name: Североисточен
       country: North Macedonia
       nuts1: MK0
       nuts2: MK00
   - MK008:
-      name: Скопски
+      area_name: Скопски
       country: North Macedonia
       nuts1: MK0
       nuts2: MK00
   - MKZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: North Macedonia
       nuts1: MKZ
       nuts2: MKZZ
   - AL011:
-      name: Dibër
+      area_name: Dibër
       country: Albania
       nuts1: AL0
       nuts2: AL01
   - AL012:
-      name: Durrës
+      area_name: Durrës
       country: Albania
       nuts1: AL0
       nuts2: AL01
   - AL013:
-      name: Kukës
+      area_name: Kukës
       country: Albania
       nuts1: AL0
       nuts2: AL01
   - AL014:
-      name: Lezhë
+      area_name: Lezhë
       country: Albania
       nuts1: AL0
       nuts2: AL01
   - AL015:
-      name: Shkodër
+      area_name: Shkodër
       country: Albania
       nuts1: AL0
       nuts2: AL01
   - AL021:
-      name: Elbasan
+      area_name: Elbasan
       country: Albania
       nuts1: AL0
       nuts2: AL02
   - AL022:
-      name: Tiranë
+      area_name: Tiranë
       country: Albania
       nuts1: AL0
       nuts2: AL02
   - AL031:
-      name: Berat
+      area_name: Berat
       country: Albania
       nuts1: AL0
       nuts2: AL03
   - AL032:
-      name: Fier
+      area_name: Fier
       country: Albania
       nuts1: AL0
       nuts2: AL03
   - AL033:
-      name: Gjirokastër
+      area_name: Gjirokastër
       country: Albania
       nuts1: AL0
       nuts2: AL03
   - AL034:
-      name: Korcë
+      area_name: Korcë
       country: Albania
       nuts1: AL0
       nuts2: AL03
   - AL035:
-      name: Vlorë
+      area_name: Vlorë
       country: Albania
       nuts1: AL0
       nuts2: AL03
   - ALZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Albania
       nuts1: ALZ
       nuts2: ALZZ
   - RS110:
-      name: Београдска област
+      area_name: Београдска област
       country: Serbia
       nuts1: RS1
       nuts2: RS11
   - RS121:
-      name: Западнобачка област
+      area_name: Западнобачка област
       country: Serbia
       nuts1: RS1
       nuts2: RS12
   - RS122:
-      name: Јужнобанатска област
+      area_name: Јужнобанатска област
       country: Serbia
       nuts1: RS1
       nuts2: RS12
   - RS123:
-      name: Јужнобачка област
+      area_name: Јужнобачка област
       country: Serbia
       nuts1: RS1
       nuts2: RS12
   - RS124:
-      name: Севернобанатска област
+      area_name: Севернобанатска област
       country: Serbia
       nuts1: RS1
       nuts2: RS12
   - RS125:
-      name: Севернобачка област
+      area_name: Севернобачка област
       country: Serbia
       nuts1: RS1
       nuts2: RS12
   - RS126:
-      name: Средњобанатска област
+      area_name: Средњобанатска област
       country: Serbia
       nuts1: RS1
       nuts2: RS12
   - RS127:
-      name: Сремска област
+      area_name: Сремска област
       country: Serbia
       nuts1: RS1
       nuts2: RS12
   - RS211:
-      name: Златиборска област
+      area_name: Златиборска област
       country: Serbia
       nuts1: RS2
       nuts2: RS21
   - RS212:
-      name: Колубарска област
+      area_name: Колубарска област
       country: Serbia
       nuts1: RS2
       nuts2: RS21
   - RS213:
-      name: Мачванска област
+      area_name: Мачванска област
       country: Serbia
       nuts1: RS2
       nuts2: RS21
   - RS214:
-      name: Моравичка област
+      area_name: Моравичка област
       country: Serbia
       nuts1: RS2
       nuts2: RS21
   - RS215:
-      name: Поморавска област
+      area_name: Поморавска област
       country: Serbia
       nuts1: RS2
       nuts2: RS21
   - RS216:
-      name: Расинска област
+      area_name: Расинска област
       country: Serbia
       nuts1: RS2
       nuts2: RS21
   - RS217:
-      name: Рашка област
+      area_name: Рашка област
       country: Serbia
       nuts1: RS2
       nuts2: RS21
   - RS218:
-      name: Шумадијска област
+      area_name: Шумадијска област
       country: Serbia
       nuts1: RS2
       nuts2: RS21
   - RS221:
-      name: Борска област
+      area_name: Борска област
       country: Serbia
       nuts1: RS2
       nuts2: RS22
   - RS222:
-      name: Браничевска област
+      area_name: Браничевска област
       country: Serbia
       nuts1: RS2
       nuts2: RS22
   - RS223:
-      name: Зајечарска област
+      area_name: Зајечарска област
       country: Serbia
       nuts1: RS2
       nuts2: RS22
   - RS224:
-      name: Јабланичка област
+      area_name: Јабланичка област
       country: Serbia
       nuts1: RS2
       nuts2: RS22
   - RS225:
-      name: Нишавска област
+      area_name: Нишавска област
       country: Serbia
       nuts1: RS2
       nuts2: RS22
   - RS226:
-      name: Пиротска област
+      area_name: Пиротска област
       country: Serbia
       nuts1: RS2
       nuts2: RS22
   - RS227:
-      name: Подунавска област
+      area_name: Подунавска област
       country: Serbia
       nuts1: RS2
       nuts2: RS22
   - RS228:
-      name: Пчињска област
+      area_name: Пчињска област
       country: Serbia
       nuts1: RS2
       nuts2: RS22
   - RS229:
-      name: Топличка област
+      area_name: Топличка област
       country: Serbia
       nuts1: RS2
       nuts2: RS22
   - RSZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Serbia
       nuts1: RSZ
       nuts2: RSZZ
   - TR100 :
-      name: İstanbul
+      area_name: İstanbul
       country: Turkey
       nuts1: TR1
       nuts2: TR10 
   - TR211:
-      name: Tekirdağ
+      area_name: Tekirdağ
       country: Turkey
       nuts1: TR2
       nuts2: TR21
   - TR212:
-      name: Edirne
+      area_name: Edirne
       country: Turkey
       nuts1: TR2
       nuts2: TR21
   - TR213:
-      name: Kırklareli
+      area_name: Kırklareli
       country: Turkey
       nuts1: TR2
       nuts2: TR21
   - TR221:
-      name: Balıkesir
+      area_name: Balıkesir
       country: Turkey
       nuts1: TR2
       nuts2: TR22
   - TR222:
-      name: Çanakkale
+      area_name: Çanakkale
       country: Turkey
       nuts1: TR2
       nuts2: TR22
   - TR310 :
-      name: İzmir
+      area_name: İzmir
       country: Turkey
       nuts1: TR3
       nuts2: TR31
   - TR321:
-      name: Aydın
+      area_name: Aydın
       country: Turkey
       nuts1: TR3
       nuts2: TR32
   - TR322:
-      name: Denizli
+      area_name: Denizli
       country: Turkey
       nuts1: TR3
       nuts2: TR32
   - TR323:
-      name: Muğla
+      area_name: Muğla
       country: Turkey
       nuts1: TR3
       nuts2: TR32
   - TR331:
-      name: Manisa
+      area_name: Manisa
       country: Turkey
       nuts1: TR3
       nuts2: TR33
   - TR332:
-      name: Afyonkarahisar
+      area_name: Afyonkarahisar
       country: Turkey
       nuts1: TR3
       nuts2: TR33
   - TR333:
-      name: Kütahya
+      area_name: Kütahya
       country: Turkey
       nuts1: TR3
       nuts2: TR33
   - TR334:
-      name: Uşak
+      area_name: Uşak
       country: Turkey
       nuts1: TR3
       nuts2: TR33
   - TR411:
-      name: Bursa
+      area_name: Bursa
       country: Turkey
       nuts1: TR4
       nuts2: TR41
   - TR412:
-      name: Eskişehir
+      area_name: Eskişehir
       country: Turkey
       nuts1: TR4
       nuts2: TR41
   - TR413:
-      name: Bilecik
+      area_name: Bilecik
       country: Turkey
       nuts1: TR4
       nuts2: TR41
   - TR421:
-      name: Kocaeli
+      area_name: Kocaeli
       country: Turkey
       nuts1: TR4
       nuts2: TR42
   - TR422:
-      name: Sakarya
+      area_name: Sakarya
       country: Turkey
       nuts1: TR4
       nuts2: TR42
   - TR423:
-      name: Düzce
+      area_name: Düzce
       country: Turkey
       nuts1: TR4
       nuts2: TR42
   - TR424:
-      name: Bolu
+      area_name: Bolu
       country: Turkey
       nuts1: TR4
       nuts2: TR42
   - TR425:
-      name: Yalova
+      area_name: Yalova
       country: Turkey
       nuts1: TR4
       nuts2: TR42
   - TR510 :
-      name: Ankara
+      area_name: Ankara
       country: Turkey
       nuts1: TR5
       nuts2: TR51
   - TR521:
-      name: Konya
+      area_name: Konya
       country: Turkey
       nuts1: TR5
       nuts2: TR52
   - TR522:
-      name: Karaman
+      area_name: Karaman
       country: Turkey
       nuts1: TR5
       nuts2: TR52
   - TR611:
-      name: Antalya
+      area_name: Antalya
       country: Turkey
       nuts1: TR6
       nuts2: TR61
   - TR612:
-      name: Isparta
+      area_name: Isparta
       country: Turkey
       nuts1: TR6
       nuts2: TR61
   - TR613:
-      name: Burdur
+      area_name: Burdur
       country: Turkey
       nuts1: TR6
       nuts2: TR61
   - TR621:
-      name: Adana
+      area_name: Adana
       country: Turkey
       nuts1: TR6
       nuts2: TR62
   - TR622:
-      name: Mersin
+      area_name: Mersin
       country: Turkey
       nuts1: TR6
       nuts2: TR62
   - TR631:
-      name: Hatay
+      area_name: Hatay
       country: Turkey
       nuts1: TR6
       nuts2: TR63
   - TR632:
-      name: Kahramanmaraş
+      area_name: Kahramanmaraş
       country: Turkey
       nuts1: TR6
       nuts2: TR63
   - TR633:
-      name: Osmaniye
+      area_name: Osmaniye
       country: Turkey
       nuts1: TR6
       nuts2: TR63
   - TR711:
-      name: Kırıkkale
+      area_name: Kırıkkale
       country: Turkey
       nuts1: TR7
       nuts2: TR71
   - TR712:
-      name: Aksaray
+      area_name: Aksaray
       country: Turkey
       nuts1: TR7
       nuts2: TR71
   - TR713:
-      name: Niğde
+      area_name: Niğde
       country: Turkey
       nuts1: TR7
       nuts2: TR71
   - TR714:
-      name: Nevşehir
+      area_name: Nevşehir
       country: Turkey
       nuts1: TR7
       nuts2: TR71
   - TR715:
-      name: Kırşehir
+      area_name: Kırşehir
       country: Turkey
       nuts1: TR7
       nuts2: TR71
   - TR721:
-      name: Kayseri
+      area_name: Kayseri
       country: Turkey
       nuts1: TR7
       nuts2: TR72
   - TR722:
-      name: Sivas
+      area_name: Sivas
       country: Turkey
       nuts1: TR7
       nuts2: TR72
   - TR723:
-      name: Yozgat
+      area_name: Yozgat
       country: Turkey
       nuts1: TR7
       nuts2: TR72
   - TR811:
-      name: Zonguldak
+      area_name: Zonguldak
       country: Turkey
       nuts1: TR8
       nuts2: TR81
   - TR812:
-      name: Karabük
+      area_name: Karabük
       country: Turkey
       nuts1: TR8
       nuts2: TR81
   - TR813:
-      name: Bartın
+      area_name: Bartın
       country: Turkey
       nuts1: TR8
       nuts2: TR81
   - TR821:
-      name: Kastamonu
+      area_name: Kastamonu
       country: Turkey
       nuts1: TR8
       nuts2: TR82
   - TR822:
-      name: Çankırı
+      area_name: Çankırı
       country: Turkey
       nuts1: TR8
       nuts2: TR82
   - TR823:
-      name: Sinop
+      area_name: Sinop
       country: Turkey
       nuts1: TR8
       nuts2: TR82
   - TR831:
-      name: Samsun
+      area_name: Samsun
       country: Turkey
       nuts1: TR8
       nuts2: TR83
   - TR832:
-      name: Tokat
+      area_name: Tokat
       country: Turkey
       nuts1: TR8
       nuts2: TR83
   - TR833:
-      name: Çorum
+      area_name: Çorum
       country: Turkey
       nuts1: TR8
       nuts2: TR83
   - TR834:
-      name: Amasya
+      area_name: Amasya
       country: Turkey
       nuts1: TR8
       nuts2: TR83
   - TR901:
-      name: Trabzon
+      area_name: Trabzon
       country: Turkey
       nuts1: TR9
       nuts2: TR90 
   - TR902:
-      name: Ordu
+      area_name: Ordu
       country: Turkey
       nuts1: TR9
       nuts2: TR90 
   - TR903:
-      name: Giresun
+      area_name: Giresun
       country: Turkey
       nuts1: TR9
       nuts2: TR90 
   - TR904:
-      name: Rize
+      area_name: Rize
       country: Turkey
       nuts1: TR9
       nuts2: TR90 
   - TR905:
-      name: Artvin
+      area_name: Artvin
       country: Turkey
       nuts1: TR9
       nuts2: TR90 
   - TR906:
-      name: Gümüşhane
+      area_name: Gümüşhane
       country: Turkey
       nuts1: TR9
       nuts2: TR90 
   - TRA11:
-      name: Erzurum
+      area_name: Erzurum
       country: Turkey
       nuts1: TRA
       nuts2: TRA1
   - TRA12:
-      name: Erzincan
+      area_name: Erzincan
       country: Turkey
       nuts1: TRA
       nuts2: TRA1
   - TRA13:
-      name: Bayburt
+      area_name: Bayburt
       country: Turkey
       nuts1: TRA
       nuts2: TRA1
   - TRA21:
-      name: Ağrı
+      area_name: Ağrı
       country: Turkey
       nuts1: TRA
       nuts2: TRA2
   - TRA22:
-      name: Kars
+      area_name: Kars
       country: Turkey
       nuts1: TRA
       nuts2: TRA2
   - TRA23:
-      name: Iğdır
+      area_name: Iğdır
       country: Turkey
       nuts1: TRA
       nuts2: TRA2
   - TRA24:
-      name: Ardahan
+      area_name: Ardahan
       country: Turkey
       nuts1: TRA
       nuts2: TRA2
   - TRB11:
-      name: Malatya
+      area_name: Malatya
       country: Turkey
       nuts1: TRB
       nuts2: TRB1
   - TRB12:
-      name: Elazığ
+      area_name: Elazığ
       country: Turkey
       nuts1: TRB
       nuts2: TRB1
   - TRB13:
-      name: Bingöl
+      area_name: Bingöl
       country: Turkey
       nuts1: TRB
       nuts2: TRB1
   - TRB14:
-      name: Tunceli
+      area_name: Tunceli
       country: Turkey
       nuts1: TRB
       nuts2: TRB1
   - TRB21:
-      name: Van
+      area_name: Van
       country: Turkey
       nuts1: TRB
       nuts2: TRB2
   - TRB22:
-      name: Muş
+      area_name: Muş
       country: Turkey
       nuts1: TRB
       nuts2: TRB2
   - TRB23:
-      name: Bitlis
+      area_name: Bitlis
       country: Turkey
       nuts1: TRB
       nuts2: TRB2
   - TRB24:
-      name: Hakkari
+      area_name: Hakkari
       country: Turkey
       nuts1: TRB
       nuts2: TRB2
   - TRC11:
-      name: Gaziantep
+      area_name: Gaziantep
       country: Turkey
       nuts1: TRC
       nuts2: TRC1
   - TRC12:
-      name: Adıyaman
+      area_name: Adıyaman
       country: Turkey
       nuts1: TRC
       nuts2: TRC1
   - TRC13:
-      name: Kilis
+      area_name: Kilis
       country: Turkey
       nuts1: TRC
       nuts2: TRC1
   - TRC21:
-      name: Şanlıurfa
+      area_name: Şanlıurfa
       country: Turkey
       nuts1: TRC
       nuts2: TRC2
   - TRC22:
-      name: Diyarbakır
+      area_name: Diyarbakır
       country: Turkey
       nuts1: TRC
       nuts2: TRC2
   - TRC31:
-      name: Mardin
+      area_name: Mardin
       country: Turkey
       nuts1: TRC
       nuts2: TRC3
   - TRC32:
-      name: Batman
+      area_name: Batman
       country: Turkey
       nuts1: TRC
       nuts2: TRC3
   - TRC33:
-      name: Şırnak
+      area_name: Şırnak
       country: Turkey
       nuts1: TRC
       nuts2: TRC3
   - TRC34:
-      name: Siirt
+      area_name: Siirt
       country: Turkey
       nuts1: TRC
       nuts2: TRC3
   - TRZZZ:
-      name: Extra-Regio NUTS 3
+      area_name: Extra-Regio NUTS 3
       country: Turkey
       nuts1: TRZ
       nuts2: TRZZ

--- a/openentrance/__init__.py
+++ b/openentrance/__init__.py
@@ -1,22 +1,22 @@
 from pathlib import Path
 
-from nomenclature import CodeList
+from nomenclature.codelist import RegionCodeList
 
 
 # path to nomenclature definitions
 DEF_PATH = Path(__file__).parent.parent / "definitions" / "region"
 
 
-countries = CodeList.from_directory(
-    "region", path=DEF_PATH, file="countries.yaml"
+countries = RegionCodeList.from_directory(
+    "region", path=DEF_PATH, file_glob_pattern="countries.yaml"
 )
 """CodeList of countries"""
 
 iso_mapping = dict(
-    [(countries[c]["iso3"], c) for c in countries]
-    + [(countries[c]["iso2"], c) for c in countries]
+    [(countries[c].iso3, c) for c in countries]
+    + [(countries[c].iso2, c) for c in countries]
     # add alternative iso2 codes used by the European Commission to the mapping
-    + [(countries[c]["iso2_alt"], c) for c in countries if "iso2_alt" in countries[c]]
+    + [(countries[c].iso2_alt, c) for c in countries if "iso2_alt" in countries[c]]
 )
 """Dictionary of iso2/iso3/alternative-iso2 codes to country names"""
 
@@ -34,10 +34,12 @@ def _create_nuts_hierarchy():
     """Parse nuts3.yaml and create hierarchical dictionary"""
 
     hierarchy = dict()
-    nuts3 = CodeList.from_directory("region", path=DEF_PATH, file="nuts3.yaml")
+    nuts3 = RegionCodeList.from_directory(
+        "region", path=DEF_PATH, file_glob_pattern="nuts3.yaml"
+    )
 
-    for n3, mapping in nuts3.items():
-        country, n1, n2 = [mapping.get(i) for i in ["country", "nuts1", "nuts2"]]
+    for n3, code in nuts3.items():
+        country, n1, n2 = [getattr(code, i) for i in ["country", "nuts1", "nuts2"]]
         country_dict = _add_to(hierarchy, country, {n1: dict()})
         n1_dict = _add_to(country_dict, n1, {n2: list()})
         _add_to(n1_dict, n2, [n3])

--- a/openentrance/__init__.py
+++ b/openentrance/__init__.py
@@ -16,7 +16,11 @@ iso_mapping = dict(
     [(countries[c].iso3, c) for c in countries]
     + [(countries[c].iso2, c) for c in countries]
     # add alternative iso2 codes used by the European Commission to the mapping
-    + [(countries[c].iso2_alt, c) for c in countries if "iso2_alt" in countries[c]]
+    + [
+        (countries[c].iso2_alt, c)
+        for c in countries
+        if hasattr(countries[c], "iso2_alt")
+    ]
 )
 """Dictionary of iso2/iso3/alternative-iso2 codes to country names"""
 

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -15,38 +15,35 @@ def test_variables_fuel_types():
         "Net electricity production from natural gas "
         "(including methane from biomass or hydrogenation)"
     )
-    assert obs["description"] == exp
+    assert obs.description == exp
 
     obs = definition.variable["Secondary Energy|Electricity|Gas|w/ CCS"]
     exp = (
         "Net electricity production from natural gas (including methane "
         "from biomass or hydrogenation) with a CO2 capture component"
     )
-    assert obs["description"] == exp
+    assert obs.description == exp
 
 
 def test_variables_industry_types():
     # check that exploding of {industry} to industries works
     obs = definition.variable["Capital|iAGRI"]
     exp = "Total capital costs spend by agriculture"
-    assert obs["description"] == exp
+    assert obs.description == exp
 
 
 def test_variables_transport_mode():
     # check that exploding of {Transport mode} to transportation modes works
     obs = definition.variable["Energy Service|Transportation|Freight|Rail"]
-    exp = (
-        "Provision of energy services related to freight "
-        "rail-based transportation"
-    )
-    assert obs["description"] == exp
+    exp = "Provision of energy services related to freight " "rail-based transportation"
+    assert obs.description == exp
 
 
 def test_variables_product_types():
     # check that exploding of {product} to products works
     obs = definition.variable["Consumption|Households|pAGRI|Imported"]
     exp = "Consumption of imported agriculture by households"
-    assert obs["description"] == exp
+    assert obs.description == exp
 
 
 def test_regions():


### PR DESCRIPTION
Changing the attribute `name` in the region codelist files `nuts1.yaml`, `nuts2.yaml` and `nuts3.yaml` to `area_name`. 
An attribute named `name` causes issues with the latest nomenclature release.
Running the tests, it seems we have another issue that will need to be fixed on the nomenclature side concerning multiple units.