### PR TITLE
Quickfix for dimensionless units

### DIFF
--- a/definitions/variable/energy/energy-final.yaml
+++ b/definitions/variable/energy/energy-final.yaml
@@ -441,7 +441,7 @@
     energy_source: electricity
     energy_use: cooling
     sector: all
-    unit: 
+    unit: '-'
 - Final Energy|Electricity|Profile:
     description: Time series of Final electricity consumption profiles.
     energy_source: electricity
@@ -449,7 +449,7 @@
     note: Those coefficients, if hourly, when multiplied by a yearly energy give hourly
       energy profiles.
     sector: all
-    unit:
+    unit: '-'
 - Final Energy|Electricity|Cooling|Profile:
     description: Time series of Final electricity consumption profiles for cooling.
     energy_source: electricity
@@ -457,7 +457,7 @@
     note: Those coefficients, if hourly, when multiplied by a yearly energy give hourly
       energy profiles.
     sector: all
-    unit:
+    unit: '-'
 - Final Energy|Electricity|Heat|Profile:
     description: Time series of Final electricity consumption profiles for heating.
     energy_source: electricity
@@ -465,7 +465,7 @@
     note: Those coefficients, if hourly, when multiplied by a yearly energy give hourly
       energy.
     sector: all
-    unit:
+    unit: '-'
 - Final Energy|Electricity|Transportation|Profile:
     description: Time series of Final electricity consumption profiles for electric-transport(including
       e-cars, e-trucks).
@@ -474,7 +474,7 @@
     note: Those coefficients, if hourly, when multiplied by a yearly energy give hourly
       energy.
     sector: all
-    unit:
+    unit: '-'
 - Final Energy|Electricity|Other (excl. Heat, Cooling, Transport)|Profile:
     description: Time series of Final electricity consumption profile for non heating,
       non cooling, non e-transport uses.
@@ -483,6 +483,4 @@
     note: Those coefficients, if hourly, when multiplied by a yearly energy give hourly
       energy.
     sector: all
-    unit:
-
-    
+    unit: '-'

--- a/definitions/variable/technology/electricity-operation.yaml
+++ b/definitions/variable/technology/electricity-operation.yaml
@@ -39,9 +39,7 @@
     description: Energy spillage that could not be stored by a {Electricity Storage Type} unit. Several energy models include spillage variables related to renewable
       energy production; however, another way is to include a spillage variable to
       the {Electricity Storage Type} unit since it is the last sink of the power network
-    unit:
-    - MW
-    - GW
+    unit: [MWh, GWh]
 
 - Operation Cost|Electricity|{Electricity Input}:
     description: Operation Cost of {Electricity Input} power plants

--- a/definitions/variable/technology/power-plant.yaml
+++ b/definitions/variable/technology/power-plant.yaml
@@ -129,14 +129,10 @@
     skip-region-aggregation: true
 - Maximum Storage|Electricity|{Electricity Storage Type}:
     description: Maximum volume of a {Electricity Storage Type} unit expressed in energy
-    unit:
-    - MWh
-    - GWh
+    unit: [MWh, GWh]
 - Minimum Storage|Electricity|{Electricity Storage Type}:
     description: Minimum volume of a {Electricity Storage Type} unit expressed in energy
-    unit:
-    - MWh
-    - GWh
+    unit: [MWh, GWh]
 - Charging Efficiency|Electricity|{Electricity Storage Type}:
     description: Efficiency of charging energy for a {Electricity Storage Type}
     unit: '%'
@@ -167,4 +163,4 @@
     unit: [daily,weekly,monthly]
 - Roundtrip Efficiency|Electricity|{Electricity Storage Type}:
     description: Efficiency when charging energy from the grid to the system
-    unit:
+    unit: '-'


### PR DESCRIPTION
@amosschle reported an error when uploading dimensionless units.

The IIASA database infrastructure (the ixmp package) does not directly supported variables without any unit (aka "dimensionless"). We therefore use `-` as an indication for dimensionless.

This will be fixed in release ixmp v4.0 scheduled for spring 2023.