### PR TITLE
Remind's region mapping for MEESA

### DIFF
--- a/definitions/region/model_native_regions/meesa_v1.1.yaml
+++ b/definitions/region/model_native_regions/meesa_v1.1.yaml
@@ -8,3 +8,10 @@
   - MEESA v1.1|DEU
   - MEESA v1.1|FRA
   - MEESA v1.1|POL
+  - MEESA v1.1|ECE
+  - MEESA v1.1|ECS
+  - MEESA v1.1|ENC
+  - MEESA v1.1|ESC
+  - MEESA v1.1|ESW
+  - MEESA v1.1|EWN
+  - MEESA v1.1|NEN 


### PR DESCRIPTION
An extention of regions mapping in MEESA to improve comparability of regional results with other models.