### PR TITLE
Add the INNOPATHS regions

### DIFF
--- a/definitions/region/european-regions.yaml
+++ b/definitions/region/european-regions.yaml
@@ -102,3 +102,11 @@
   - United Kingdom & Ireland (IP):
       innopaths: UKI
       countries: UK, Ireland
+
+- European (non-EU) north countries (IP):
+      innopaths: NEN
+      countries: Iceland, Liechtenstein, Norway, Switzerland
+
+- European (non-EU) south countries (IP):
+      innopaths: NES
+      countries: Albania, Andorra, Bosnia and Herzegovina, North Macedonia, Monaco, Montenegro, Serbia, Turkey

--- a/definitions/region/european-regions.yaml
+++ b/definitions/region/european-regions.yaml
@@ -102,11 +102,10 @@
   - United Kingdom & Ireland (IP):
       innopaths: UKI
       countries: UK, Ireland
-
-- European (non-EU) north countries (IP):
+  - Northern (non-EU) Europe (IP):
       innopaths: NEN
       countries: Iceland, Liechtenstein, Norway, Switzerland
-
-- European (non-EU) south countries (IP):
+  - Southern (non-EU) Europe (IP):
       innopaths: NES
-      countries: Albania, Andorra, Bosnia and Herzegovina, North Macedonia, Monaco, Montenegro, Serbia, Turkey
+      countries: Albania, Andorra, Bosnia and Herzegovina, North Macedonia, Monaco,
+        Montenegro, Serbia, Turkey

--- a/definitions/region/european-regions.yaml
+++ b/definitions/region/european-regions.yaml
@@ -102,10 +102,10 @@
   - United Kingdom & Ireland (IP):
       innopaths: UKI
       countries: UK, Ireland
-  - Northern (non-EU) Europe (IP):
+  - Northern non-EU Europe (IP):
       innopaths: NEN
       countries: Iceland, Liechtenstein, Norway, Switzerland
-  - Southern (non-EU) Europe (IP):
+  - Southern non-EU Europe (IP):
       innopaths: NES
       countries: Albania, Andorra, Bosnia and Herzegovina, North Macedonia, Monaco,
         Montenegro, Serbia, Turkey

--- a/definitions/region/european-regions.yaml
+++ b/definitions/region/european-regions.yaml
@@ -72,3 +72,33 @@
       definition: EU27 excluding CY + MT
 
   # add more definitions of `EU*` above this line
+
+  # region definition from the INNOPATHS project
+- INNOPATHS regions:
+  - Germany (IP):
+      innopaths: DEU
+      countries: Germany
+  - Eastern Europe (IP):
+      innopaths: ECE
+      countries: Czech Republic, Estonia, Latvia, Lithuania, Poland, Slovakia
+  - Scandinavia (IP):
+      innopaths: ENC
+      countries: Denmark, Finland, Sweden
+  - South-East Europe (IP):
+      innopaths: ECS
+      countries: Bulgaria, Croatia, Hungary, Romania, Slovenia
+  - Southern Europe (IP):
+      innopaths: ESC
+      countries: Cyprus, Greece, Italy, Malta
+  - Iberian Peninsula (IP):
+      innopaths: ESW
+      countries: Portugal, Spain
+  - Central Europe (IP):
+      innopaths: EWN
+      countries: Austria, Belgium, Luxembourg, Netherlands
+  - France (IP):
+      innopaths: FRA
+      countries: France
+  - United Kingdom & Ireland (IP):
+      innopaths: UKI
+      countries: UK, Ireland


### PR DESCRIPTION
Per email conversations with @tatar99 and the PRIMES team, this PR adds the regions from the INNOPATHS project for easier comparison between REMIND, PRIMES, and other models.

I took the liberty to come up with "readable" region names instead of the abbreviations and added the suffix `(IP)` such that the regions can easily be identified in a large ensemble (with many different region aggregations, similar to adding `(R5)` in the global region).

FYI @HauHe 