### PR TITLE
Upgrade nomenclature to v0.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyam-iamc>=1.0  # the pyam package is released on pypi under this name
 iam-units>=2021.11.12
-git+https://github.com/IAMconsortium/nomenclature.git
+nomenclature-iamc>=0.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ packages = openentrance
 install_requires =
     setuptools >= 41
     pyyaml
-    nomenclature-iamc < 0.8
+    nomenclature-iamc >= 0.8
     pyam-iamc >= 1.0  # the pyam package is released on pypi under this name
     iam-units >= 2021.11.12
 setup_requires =

--- a/workflow.py
+++ b/workflow.py
@@ -31,7 +31,7 @@ def main(df: pyam.IamDataFrame, dimensions=["region", "variable"]) -> pyam.IamDa
     definition = DataStructureDefinition(
         here / "definitions", dimensions=dsd_dimensions
     )
-    processor = RegionProcessor.from_directory(path=here / "mappings")
+    processor = RegionProcessor.from_directory(here / "mappings", definition)
 
     # check if directional data exists in the scenario data, add to region codelist
     if any([r for r in df.region if ">" in r]):


### PR DESCRIPTION
This PR updates the workflow to be compatible with nomenclature v0.8 and changes the way that the workflow module is imported in the tests.