### PR TITLE
Fix failing tests in GitHub Actions recipe

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,8 +24,9 @@ jobs:
 
     - name: Install dependencies
       run: |
+        pip install --upgrade pip
         pip install -r requirements.txt
-        pip install pytest
+        pip install "pytest<7.2.3"
 
     - name: Install and test package functions
       run: |

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5,7 +5,7 @@ import pytest
 
 import sys
 
-sys.path.append(Path(__file__).parent)
+sys.path.append(Path(__file__).parents[1])
 print(sys.path)
 from workflow import main as workflow
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5,7 +5,7 @@ import pytest
 
 import sys
 
-sys.path.append(Path(__file__).parents[1])
+sys.path.append(str(Path(__file__).parents[1]))
 print(sys.path)
 from workflow import main as workflow
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -5,8 +5,8 @@ import pytest
 
 import sys
 
+# this is necessary to make tests pass on GitHub Actions
 sys.path.append(str(Path(__file__).parents[1]))
-print(sys.path)
 from workflow import main as workflow
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,11 +1,12 @@
+from pathlib import Path
 import pandas as pd
 from pyam import IamDataFrame
 import pytest
 
 import sys
 
-sys.path.append("..")
-
+sys.path.append(Path(__file__).parent)
+print(sys.path)
 from workflow import main as workflow
 
 


### PR DESCRIPTION
There was some change in how `sys.path("..")` was interpreted...