### PR TITLE
add approximate EU regions to region mapping

### DIFF
--- a/mappings/remind_2.1.yaml
+++ b/mappings/remind_2.1.yaml
@@ -25,6 +25,10 @@ native_regions:
   - EU27
   - World
 common_regions:
+  - EU27 & UK (*): 
+      - EUR
+  - EU27 (*): 
+      - EU27
   - Germany:
       - DEU
   - France:


### PR DESCRIPTION
Add approximate EU regions "EU27 (*)" and "EU27 & UK (*)" to REMIND region mapping