### PR TITLE
update remind_3.0 to add approximate EU regions

### DIFF
--- a/mappings/remind_3.0.yaml
+++ b/mappings/remind_3.0.yaml
@@ -29,6 +29,10 @@ native_regions:
   - EU27
   - World
 common_regions:
+  - EU27 & UK (*): 
+      - EUR
+  - EU27 (*): 
+      - EU27
   - Germany:
       - DEU
   - France:


### PR DESCRIPTION
Add approximate EU regions "EU27 (\*)" and "EU27 & UK (\*)" to REMIND 3.0 region mapping