### PR TITLE
Refactor to use nomenclature v0.9

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
+        pip install pytest
 
     - name: Install and test package functions
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,12 +22,8 @@ jobs:
       with:
         python-version: 3.9
 
-    - name: Install dependencies
+    - name: Install the package and run the tests
       run: |
         pip install --upgrade pip
-        pip install pytest
-
-    - name: Install and test package functions
-      run: |
-        pip install --editable .
+        pip install --editable .[tests]
         pytest tests

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,8 +25,6 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install "pytest<7.2.3"
 
     - name: Install and test package functions
       run: |

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: 3.9
 
     - name: Install dependencies
-      run: pip install -r requirements.txt
+      run: pip install nomenclature-iamc
 
     - name: Run the nomenclature project validation
       run: nomenclature validate-project . --dimensions "['region', 'scenario', 'variable']"

--- a/openentrance/README.md
+++ b/openentrance/README.md
@@ -25,7 +25,6 @@ Then navigate the command prompt to the new folder and install using pip.
 
 ```
 $ cd openentrance
-$ pip install -r requirements.txt
 $ pip install --editable .
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-pyam-iamc>=1.0  # the pyam package is released on pypi under this name
-iam-units>=2021.11.12
-git+https://github.com/IAMconsortium/nomenclature.git

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,3 +19,7 @@ install_requires =
 setup_requires =
     setuptools >= 41
     setuptools_scm
+
+[options.extras_require]
+tests =
+    pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ packages = openentrance
 install_requires =
     setuptools >= 41
     pyyaml
-    nomenclature-iamc < 0.8
+    nomenclature-iamc >= 0.9
     pyam-iamc >= 1.0  # the pyam package is released on pypi under this name
     iam-units >= 2021.11.12
 setup_requires =

--- a/workflow.py
+++ b/workflow.py
@@ -31,7 +31,7 @@ def main(df: pyam.IamDataFrame, dimensions=["region", "variable"]) -> pyam.IamDa
     definition = DataStructureDefinition(
         here / "definitions", dimensions=dsd_dimensions
     )
-    processor = RegionProcessor.from_directory(path=here / "mappings")
+    processor = RegionProcessor.from_directory(here / "mappings", definition)
 
     # check if directional data exists in the scenario data, add to region codelist
     if any([r for r in df.region if ">" in r]):


### PR DESCRIPTION
This PR upgrades the workflow to use nomenclature v0.9 and removes the explicit `requirements.txt`.