### PR TITLE
Adding EU27 & UK (*) for OSeMBE

### DIFF
--- a/mappings/eu-countries.yaml
+++ b/mappings/eu-countries.yaml
@@ -96,6 +96,35 @@ common_regions:
     - Sweden
     - The Netherlands
     - United Kingdom
+  - EU27 & UK (*):
+    - Austria
+    - Belgium
+    - Bulgaria
+    - Croatia
+    - Cyprus
+    - Czech Republic
+    - Denmark
+    - Estonia
+    - Finland
+    - France
+    - Germany
+    - Greece
+    - Hungary
+    - Ireland
+    - Italy
+    - Latvia
+    - Lithuania
+    - Luxembourg
+    - Malta
+    - Poland
+    - Portugal
+    - Romania
+    - Slovakia
+    - Slovenia
+    - Spain
+    - Sweden
+    - The Netherlands
+    - United Kingdom
   - EU27 & EFTA:
     - Austria
     - Belgium

--- a/mappings/eu-countries.yaml
+++ b/mappings/eu-countries.yaml
@@ -96,6 +96,34 @@ common_regions:
     - Sweden
     - The Netherlands
     - United Kingdom
+  - EU27 (*):
+    - Austria
+    - Belgium
+    - Bulgaria
+    - Croatia
+    - Cyprus
+    - Czech Republic
+    - Denmark
+    - Estonia
+    - Finland
+    - France
+    - Germany
+    - Greece
+    - Hungary
+    - Ireland
+    - Italy
+    - Latvia
+    - Lithuania
+    - Luxembourg
+    - Malta
+    - Poland
+    - Portugal
+    - Romania
+    - Slovakia
+    - Slovenia
+    - Spain
+    - Sweden
+    - The Netherlands
   - EU27 & UK (*):
     - Austria
     - Belgium


### PR DESCRIPTION
Added "EU27 & UK (*)" under "common regions". This region is the same as our "EU27 & UK" but the new "EU27 & UK (*)" region is added so that a filter for "EU27 & UK (*)" can be applied, and by doing so getting results from all models.