### PR TITLE
Added available secondary energy|electricity and updated units

### DIFF
--- a/definitions/variable/energy/energy-secondary.yaml
+++ b/definitions/variable/energy/energy-secondary.yaml
@@ -7,23 +7,33 @@
 
 - Secondary Energy|Electricity:
     description: Total net electricity production
-    unit: EJ/yr
+    unit: [EJ/yr, GWh]
 - Secondary Energy|Electricity|{Electricity Input}:
     description: Net electricity production from {Electricity Input}
-    unit: EJ/yr
+    unit: [EJ/yr, GWh]
+ - Available Secondary Energy|Electricity:
+    description: Total net potential electricity production
+      this is equivalent to the total electricity mix capacity multiplied by the number of hours in the period multiplied by the maximum achievable load factor
+      this is also equivalent to the Secondary Energy if all the generation assets would produce at maximum capacity during the period
+    unit: [EJ/yr, GWh]
+- Available Secondary Energy|Electricity|{Electricity Input}:
+    description: Net electricity potential production from {Electricity Input}
+      this is equivalent to the total {Electricity Input} capacity multiplied by the number of hours in the period multiplied by the maximum achievable load factor for 
+      this is also equivalent to the Secondary Energy of {Electricity Input} if all the generation assets would produce at maximum capacity during the period
+    unit: [EJ/yr, GWh]
 - Secondary Energy|Electricity|Curtailment:
     description: Curtailment of electricity production due to oversupply from
       variable renewable sources (typically from wind and solar)
-    unit: EJ/yr
+    unit: [EJ/yr, GWh]
 - Secondary Energy|Electricity|Storage:
     description: electricity storage from other periods used
-    unit: EJ/yr
+    unit: [EJ/yr, GWh]
 - Secondary Energy|Electricity|Storage Losses:
     description: losses from electricity storage
-    unit: EJ/yr
+    unit: [EJ/yr, GWh]
 - Secondary Energy|Electricity|Transmission Losses:
     description: electricity losses from long-range high-voltage transmission
-    unit: EJ/yr
+    unit: [EJ/yr, GWh]
 
 - Secondary Energy|Gases:
     description: Total production of gaseous fuels, including natural gas

--- a/definitions/variable/energy/energy-secondary.yaml
+++ b/definitions/variable/energy/energy-secondary.yaml
@@ -1,17 +1,16 @@
 # List of variables related to the secondary energy sectors
-
 - Secondary Energy:
     description: Total secondary energy, the sum of all secondary energy carrier 
       production (for consistency checks).
     unit: EJ/yr
-
+    
 - Secondary Energy|Electricity:
     description: Total net electricity production
     unit: [EJ/yr, GWh]
 - Secondary Energy|Electricity|{Electricity Input}:
     description: Net electricity production from {Electricity Input}
     unit: [EJ/yr, GWh]
- - Available Secondary Energy|Electricity:
+- Available Secondary Energy|Electricity:
     description: Total net potential electricity production
       this is equivalent to the total electricity mix capacity multiplied by the number of hours in the period multiplied by the maximum achievable load factor
       this is also equivalent to the Secondary Energy if all the generation assets would produce at maximum capacity during the period


### PR DESCRIPTION
-Available Secondary Energy|Electricity is required to upload CS5 results. It is equivalent to the Secondary Energy that would been achieved if all assets were producing at max capacity during the period considered. In particular for renewable assets, this cannot be computed by multiplying the capacity by the number of hours of the period, as it also relaies on the load factor (eg during the night PV produces 0). 
- change of units for all Secondary Energy|Electricity : the only unit allowed was EJ/yr : in power system studies, we mostly use GWh. Also Ej/yr is limitating as it implies that the variable can only be used for annual data (not subannual); In openentrance CS1,CS4 and CS5 we are uploading Secondary Energy|Electricity per seasons. We could also need monthly or weekly data. This is why I propose that the possible units are EJ/ty (which is currently used in already uploaded data), and GWh (which is needed for power system studies)