### PR TITLE
added hydro storage

### DIFF
--- a/definitions/variable/tag_electricity_storage_types.yaml
+++ b/definitions/variable/tag_electricity_storage_types.yaml
@@ -18,6 +18,20 @@
         This hydropower system has two water reservoirs at different elevations.
         The definition follows the convention established
         by the ENTSO-E transparency platform (https://transparency.entsoe.eu).
+  - Hydro|Reservoir:
+      description: hydropower systems with seasonal storage capacity
+        (possibly including pumping turbines)
+      notes: This definition follows the convention established
+        by the ENTSO-E transparency platform (https://transparency.entsoe.eu).
+  - Hydro|Pumped Storage:
+      description: hydropower systems with short-term storage capacity
+        (including pumping turbines)
+      notes: This variable should only include electricity generation from natural
+        inflow of water into the upper reservoir. Electricity from storage operation
+        should be denoted by *"Injected Energy|.."* and *Discharded Energy|..*.
+        This hydropower system has two water reservoirs at different elevations.
+        The definition follows the convention established
+        by the ENTSO-E transparency platform (https://transparency.entsoe.eu).
   - Energy Storage System|Hydro|Reservoir:
       description: hydropower systems with seasonal storage capacity
         (possibly including pumping turbines)


### PR DESCRIPTION
When we added the tags for energy storage system, the variable names for storage were redefined with an additionnal section which is |Energy Storage System|  This creates an inconsistency in variable names for hydro power: we do have Secondary Energy|Hydro|Reservoir and Capacity|Hydro|Reservoir (which are needed to remain unchainged) for instance but when we need Maximum Storage|Hydro|Reservoir does not exist, instead it is - Maximum Storage|Energy Storage System|Hydro|Pumped Storage, which is not consistent, too complicated and useless (as it is obvious that Reservoir and Pumped Storage are storage); I had thought that it could be possible to allow both names but it doesn't work as we have defined Capacity|{electricity input} and capacity|{electricity storage system} which means that a variable would be duplicated. My suggestion is then to remove Reservoir and Pumped Storage from the list of {Energy storage systems} ; 
Before doing that I added the variable which I needed which are Maximum Storage|Hydro|Reservoir  and Maximum Storage|Hydro|Pumped Storage
