### PR TITLE
Added Maximum Storage for Hydro|Reservoir and Hydro|Pumped Storage

### DIFF
--- a/definitions/variable/technology/power-plant.yaml
+++ b/definitions/variable/technology/power-plant.yaml
@@ -130,6 +130,12 @@
 - Maximum Storage|Electricity|{Electricity Storage Type}:
     description: Maximum volume of a {Electricity Storage Type} unit expressed in energy
     unit: [MWh, GWh]
+- Maximum Storage|Electricity|Hydro|Reservoir:
+    description: Maximum volume of Hydro Reservoir technology  expressed in energy
+    unit: [MWh, GWh]
+- Maximum Storage|Electricity|Hydro|Pumped Storage:
+    description: Maximum volume of Pumped Storage technology expressed in energy
+    unit: [MWh, GWh]
 - Minimum Storage|Electricity|{Electricity Storage Type}:
     description: Minimum volume of a {Electricity Storage Type} unit expressed in energy
     unit: [MWh, GWh]


### PR DESCRIPTION
When we added the tags for energy storage system, the variable names for storage were redefined with an additionnal section which is |Energy Storage System| This creates an inconsistency in variable names for hydro power: we do have Secondary Energy|Hydro|Reservoir and Capacity|Hydro|Reservoir (which are needed to remain unchainged) for instance but when we need Maximum Storage|Hydro|Reservoir does not exist, instead it is - Maximum Storage|Energy Storage System|Hydro|Pumped Storage, which is not consistent, too complicated and useless (as it is obvious that Reservoir and Pumped Storage are storage); I had thought that it could be possible to allow both names but it doesn't work as we have defined Capacity|{electricity input} and capacity|{electricity storage system} which means that a variable would be duplicated. My suggestion is then to remove Reservoir and Pumped Storage from the list of {Energy storage systems} ; Before doing that I added the variable which I needed which are Maximum Storage|Hydro|Reservoir and Maximum Storage|Hydro|Pumped Storage