### PR TITLE
Added interregional electricity flows

### DIFF
--- a/definitions/variable/technology/electricity-operation.yaml
+++ b/definitions/variable/technology/electricity-operation.yaml
@@ -110,7 +110,7 @@
     unit: MWh
 - Flow|Electricity:
     description: Flow from electricity from the former to latter region
-    unit: MWh
+    unit: [MWh, GWh]
 - Unserved Demand|Electricity:
     description: Not served demand
     unit: MWh

--- a/definitions/variable/technology/electricity-operation.yaml
+++ b/definitions/variable/technology/electricity-operation.yaml
@@ -108,7 +108,7 @@
 - Import|Electricity:
     description: Exported electricity from a given region
     unit: MWh
-- Flow|Electricity|{Region}|{Region}:
+- Flow|Electricity:
     description: Flow from electricity from the former to latter region
     unit: MWh
 - Unserved Demand|Electricity:

--- a/definitions/variable/technology/electricity-operation.yaml
+++ b/definitions/variable/technology/electricity-operation.yaml
@@ -108,6 +108,9 @@
 - Import|Electricity:
     description: Exported electricity from a given region
     unit: MWh
+- Flow|Electricity|{Region}|{Region}:
+    description: Flow from electricity from the former to latter region
+    unit: MWh
 - Unserved Demand|Electricity:
     description: Not served demand
     unit: MWh


### PR DESCRIPTION
Interregional electricity flows are required to upload CS7 results (Danish electricity imports from and exports to neighbour countries). As far as I understand, the current `Import|Electricity` and `Export|Electricity` do not allow specifying two regions.