### PR TITLE
Added max. heat storage

### DIFF
--- a/definitions/variable/tag_storage_types.yaml
+++ b/definitions/variable/tag_storage_types.yaml
@@ -29,3 +29,8 @@
       description: redox flow batteries
   - Energy Storage System|Compressed Air:
       description: compressed air storage systems
+
+- Heat Storage Type:
+
+  - Energy Storage System|Heat:
+      description: all types of heat storage systems

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -25,7 +25,7 @@
     description: Total installed heat generation capacity for the industrial sector
       from {Fuel}
     unit: GW
-- Maximum Storage|Heat:
+- Maximum Storage|{Heat Storage Type}:
     description: Maximum volume of heat storage expressed in energy
     unit: [MWh, GWh]
 - Capital Cost|Electricity|{Electricity Input}:

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -25,6 +25,9 @@
     description: Total installed heat generation capacity for the industrial sector
       from {Fuel}
     unit: GW
+- Maximum Storage|Heat:
+    description: Maximum volume of a heat storage expressed in energy
+    unit: [MWh, GWh]
 - Capital Cost|Electricity|{Electricity Input}:
     description: Capital cost for {Electricity Input}
     unit: [EUR_2020/kW, USD_2010/kW]

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -26,7 +26,7 @@
       from {Fuel}
     unit: GW
 - Maximum Storage|Heat:
-    description: Maximum volume of a heat storage expressed in energy
+    description: Maximum volume of heat storage expressed in energy
     unit: [MWh, GWh]
 - Capital Cost|Electricity|{Electricity Input}:
     description: Capital cost for {Electricity Input}


### PR DESCRIPTION
CS7 results include maximum heat storage (MWh). If I understand correctly, only electricity storage is supported by the nomenclature, currently.