### PR TITLE
Add European approximate region for PRIMES 2022

### DIFF
--- a/mappings/primes_2022.yaml
+++ b/mappings/primes_2022.yaml
@@ -1,0 +1,19 @@
+model:
+  - PRIMES 2022
+
+native_regions:
+  - EU27
+  - EU27 & UK
+  - Central Europe (IP)
+  - Eastern Europe (IP)
+  - Iberian Peninsula (IP)
+  - Scandinavia (IP)
+  - South-East Europe (IP)
+  - Southern Europe (IP)
+  - United Kingdom & Ireland (IP)
+
+common_regions:
+  - EU27 (*):
+      - EU27
+  - EU27 & UK (*):
+      - EU27 & UK


### PR DESCRIPTION
I think it is a bit odd to have some but not all of the INNOPATHS regions, but there are some scenarios in this way, so I added them here in the mapping as natively-reported regions.

@fragkos1985, please approve the mapping.

fyi @robertpietzcker 

