### PR TITLE
add missing WP5p1 scenarios

### DIFF
--- a/definitions/scenario/scenarios.yaml
+++ b/definitions/scenario/scenarios.yaml
@@ -97,3 +97,5 @@
 - WP5 Russia-1150
 - WP5 EastWest-650
 - WP5 EastWest-1150
+- WP5 EastWestTech-650
+- WP5 EastWestTech-1150


### PR DESCRIPTION
Adding EastWest Tech scenarios defined in ECEMF WP5.1 protocol document, version 1.5.