### PR TITLE
Adding Secondary Energy|Electricity|Other|Fossil variable support

### DIFF
--- a/definitions/variable/tag_electricity_input_types.yaml
+++ b/definitions/variable/tag_electricity_input_types.yaml
@@ -39,7 +39,6 @@
 
   - Fossil:
       description: all fossil fuels (crude oil, coal, natural gas, non-bio waste and fossil industrial gases)
-)
   - Fossil|w/ CCS:
       description: all fossil fuels (crude oil, coal, natural gas, non-bio waste and fossil industrial gases)
         with a CO2 capture component

--- a/definitions/variable/tag_electricity_input_types.yaml
+++ b/definitions/variable/tag_electricity_input_types.yaml
@@ -328,6 +328,8 @@
       description: ocean energy
 
   - Other:
-      description: other energy sources and fuels not explicitely listed
+      description: other energy sources and fuels not explicitly listed
   - Other|Fossil:
-      description: other fossil energy sources and fuels not explicitely listed (e.g. fossil waste and fossil industrial gases)
+      description: other fossil energy sources and fuels not explicitly listed (e.g. fossil waste and fossil industrial gases)
+  - Other|Non-Fossil:
+      description: other non-fossil energy sources and fuels not explicitly listed (e.g. biomass waste)

--- a/definitions/variable/tag_electricity_input_types.yaml
+++ b/definitions/variable/tag_electricity_input_types.yaml
@@ -38,12 +38,13 @@
         with freely vented CO2 emissions
 
   - Fossil:
-      description: all fossil fuels (crude oil, coal, natural gas)
+      description: all fossil fuels (crude oil, coal, natural gas, non-bio waste and fossil industrial gases)
+)
   - Fossil|w/ CCS:
-      description: all fossil fuels (crude oil, coal, natural gas)
+      description: all fossil fuels (crude oil, coal, natural gas, non-bio waste and fossil industrial gases)
         with a CO2 capture component
   - Fossil|w/o CCS:
-      description: all fossil fuels (crude oil, coal, natural gas)
+      description: all fossil fuels (crude oil, coal, natural gas, non-bio waste and fossil industrial gases)
         with freely vented CO2 emissions
 
   - Coal:

--- a/definitions/variable/tag_electricity_input_types.yaml
+++ b/definitions/variable/tag_electricity_input_types.yaml
@@ -38,12 +38,12 @@
         with freely vented CO2 emissions
 
   - Fossil:
-      description: all fossil fuels (crude oil, coal, natural gas, non-bio waste and fossil industrial gases)
+      description: all fossil fuels (crude oil, coal, natural gas, fossil waste and fossil industrial gases)
   - Fossil|w/ CCS:
-      description: all fossil fuels (crude oil, coal, natural gas, non-bio waste and fossil industrial gases)
+      description: all fossil fuels (crude oil, coal, natural gas, fossil waste and fossil industrial gases)
         with a CO2 capture component
   - Fossil|w/o CCS:
-      description: all fossil fuels (crude oil, coal, natural gas, non-bio waste and fossil industrial gases)
+      description: all fossil fuels (crude oil, coal, natural gas, fossil waste and fossil industrial gases)
         with freely vented CO2 emissions
 
   - Coal:
@@ -330,4 +330,4 @@
   - Other:
       description: other energy sources and fuels not explicitely listed
   - Other|Fossil:
-      description: other fossil energy sources and fuels not explicitely listed (e.g. non-bio waste and fossil industrial gases)
+      description: other fossil energy sources and fuels not explicitely listed (e.g. fossil waste and fossil industrial gases)

--- a/definitions/variable/tag_electricity_input_types.yaml
+++ b/definitions/variable/tag_electricity_input_types.yaml
@@ -329,3 +329,5 @@
 
   - Other:
       description: other energy sources and fuels not explicitely listed
+  - Other|Fossil:
+      description: other fossil energy sources and fuels not explicitely listed (e.g. non-bio waste and fossil industrial gases)


### PR DESCRIPTION
Adding `Secondary Energy|Electricity|Other|Fossil` variable support to allow detailed report of electricity produced from fossil waste and fossil industrial gases