### PR TITLE
Expanding the data format structure of region to allow specifying three regions

### DIFF
--- a/definitions/region/README.md
+++ b/definitions/region/README.md
@@ -143,16 +143,20 @@ Example:
 > Norway>Germany
 
 To represent data that refers to a flow or cost contribution of a region
-to a connection between two regions, the third contributing region name 
+to a connection between two regions, the contributing region name 
 can be combined with the bi-directional data using a `:` character before
 the bi-directional data (without spaces before/after that character).
-
-The third contributing region can be of **a different level of spatial detail**
-from the bi-directional data.
 
 Example:
 
 > Germany:France>Spain
+
+The contributing region can be of **a different level of spatial detail**
+from the two regions specified in the bi-directional data.
+
+Example:
+
+> Berlin:France>Spain
 
 ## Parallel connections of directional data
 

--- a/definitions/region/README.md
+++ b/definitions/region/README.md
@@ -142,21 +142,17 @@ Example:
 
 > Norway>Germany
 
-To represent data that refers to a flow or cost contribution of a region
-to a connection between two regions, the contributing region name 
-can be combined with the bi-directional data using a `:` character before
-the bi-directional data (without spaces before/after that character).
+To represent data that refers to a flow or cost contribution of a generator
+or a demand in a region to a connection between two regions, the name of the region
+of the contributing agent (generator or demand) can be combined with the bi-directional data using 
+a `:` character before the bi-directional data (without spaces before/after that character).
 
-Example:
-
-> Germany:France>Spain
-
-The contributing region can be of **a different level of spatial detail**
+The region of the contributing agent can be of **a different level of spatial detail**
 from the two regions specified in the bi-directional data.
 
 Example:
 
-> Berlin:France>Spain
+> DE30:France>Spain
 
 ## Parallel connections of directional data
 

--- a/definitions/region/README.md
+++ b/definitions/region/README.md
@@ -142,6 +142,18 @@ Example:
 
 > Norway>Germany
 
+To represent data that refers to a flow or cost contribution of a region
+to a connection between two regions, the third contributing region name 
+can be combined with the bi-directional data using a `:` character before
+the bi-directional data (without spaces before/after that character).
+
+The third contributing region can be of **a different level of spatial detail**
+from the bi-directional data.
+
+Example:
+
+> Germany:France>Spain
+
 ## Parallel connections of directional data
 
 When timeseries data represents flows or capacity on one of several parallel

--- a/definitions/variable/technology/electricity-grid.yaml
+++ b/definitions/variable/technology/electricity-grid.yaml
@@ -28,10 +28,14 @@
 - Network|Electricity|Active Power Flow:
     description: Active power flow through a line
     unit: MW
-- Network|Electricity|Active Power Flow|Generation Contribution:
+- Network|Electricity|Active Power Flow|Flow Contribution:
+    description: The active power flow that agents (generators and demand) 
+      in a certain (sub)region are causing on a line
+    unit: MW
+- Network|Electricity|Active Power Flow|Flow Contribution|Generation:
     description: The active power flow that a generator(s) is causing on a line
     unit: MW
-- Network|Electricity|Active Power Flow|Demand Contribution:
+- Network|Electricity|Active Power Flow|Flow Contribution|Demand:
     description: The active power flow that demand is causing on a line
     unit: MW
 - Network|Electricity|Impedance:
@@ -41,11 +45,16 @@
     description: Overnight investment (capital) cost in transmission lines of the
       power network
     unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Network|Electricity|Allocated Investment|Generation:
+- Network|Electricity|Investment|Allocated Investment:
+    description: Overnight investment (capital) cost in a transmission line of the
+      power network allocated to agents (generators and demand) in a certain (sub)region 
+      based on their electrical usage
+    unit: [thousand EUR_2020/yr, thousand USD_2010/yr]
+- Network|Electricity|Investment|Allocated Investment|Generation:
     description: Overnight investment (capital) cost in a transmission line of the
       power network allocated to a generator(s) based on its electrical usage
     unit: [thousand EUR_2020/yr, thousand USD_2010/yr]
-- Network|Electricity|Allocated Investment|Demand:
+- Network|Electricity|Investment|Allocated Investment|Demand:
     description: Overnight investment (capital) cost in a transmission line of the
       power network allocated to demand based on its electrical usage
     unit: [thousand EUR_2020/yr, thousand USD_2010/yr]

--- a/definitions/variable/technology/electricity-grid.yaml
+++ b/definitions/variable/technology/electricity-grid.yaml
@@ -28,6 +28,12 @@
 - Network|Electricity|Active Power Flow:
     description: Active power flow through a line
     unit: MW
+- Network|Electricity|Active Power Flow Generation Contribution:
+    description: The active power flow that a generator is causing on a line
+    unit: MW
+- Network|Electricity|Active Power Flow Demand Contribution:
+    description: The active power flow that a demand is causing on a line
+    unit: MW
 - Network|Electricity|Impedance:
     description: Impedance of an interconnection between 2 regions
     unit: S
@@ -35,6 +41,14 @@
     description: Overnight investment (capital) cost in transmission lines of the
       power network
     unit: [million EUR_2020/yr, billion USD_2010/yr]
+- Network|Electricity|Generation Allocated Investment:
+    description: Overnight investment (capital) cost in a transmission line of the
+      power network allocated to a generator based on its electrical usage
+    unit: [thousand EUR_2020/yr, thousand USD_2010/yr]
+- Network|Electricity|Demand Allocated Investment:
+    description: Overnight investment (capital) cost in a transmission line of the
+      power network allocated to a demand based on its electrical usage
+    unit: [thousand EUR_2020/yr, thousand USD_2010/yr]
 - Network|Electricity|Fixed Charge Rate:
     description: Fixed charge rate to annualize the overnight investment cost. The
       Fixed Charge Rate (FCR) is the percentage of the total investment cost that

--- a/definitions/variable/technology/electricity-grid.yaml
+++ b/definitions/variable/technology/electricity-grid.yaml
@@ -28,11 +28,11 @@
 - Network|Electricity|Active Power Flow:
     description: Active power flow through a line
     unit: MW
-- Network|Electricity|Active Power Flow Generation Contribution:
-    description: The active power flow that a generator is causing on a line
+- Network|Electricity|Active Power Flow|Generation Contribution:
+    description: The active power flow that a generator(s) is causing on a line
     unit: MW
-- Network|Electricity|Active Power Flow Demand Contribution:
-    description: The active power flow that a demand is causing on a line
+- Network|Electricity|Active Power Flow|Demand Contribution:
+    description: The active power flow that demand is causing on a line
     unit: MW
 - Network|Electricity|Impedance:
     description: Impedance of an interconnection between 2 regions
@@ -41,13 +41,13 @@
     description: Overnight investment (capital) cost in transmission lines of the
       power network
     unit: [million EUR_2020/yr, billion USD_2010/yr]
-- Network|Electricity|Generation Allocated Investment:
+- Network|Electricity|Allocated Investment|Generation:
     description: Overnight investment (capital) cost in a transmission line of the
-      power network allocated to a generator based on its electrical usage
+      power network allocated to a generator(s) based on its electrical usage
     unit: [thousand EUR_2020/yr, thousand USD_2010/yr]
-- Network|Electricity|Demand Allocated Investment:
+- Network|Electricity|Allocated Investment|Demand:
     description: Overnight investment (capital) cost in a transmission line of the
-      power network allocated to a demand based on its electrical usage
+      power network allocated to demand based on its electrical usage
     unit: [thousand EUR_2020/yr, thousand USD_2010/yr]
 - Network|Electricity|Fixed Charge Rate:
     description: Fixed charge rate to annualize the overnight investment cost. The


### PR DESCRIPTION
Updated the README.md of region to describe the expansion we need to implement to the region definition so that we can integrate the output of InfraCost.
Please check the proposed expansion of the data format structure of region and advise on how to implement it.
With due thanks.