### PR TITLE
add buildings costs - investment and running

### DIFF
--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -230,6 +230,20 @@
     description: Investments into heat pumps for use in {Residential/Commercial} buildings
     unit: [million EUR_2020/yr, billion USD_2010/yr]
 
+
+- Investment|Energy Demand|{Residential/Commercial}:
+    description: Total investments in {Residential/Commercial}
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Investment|Energy Demand|{Residential/Commercial}|Appliances:
+    description: Investments into non-heating/cooling appliances in {Residential/Commercial}
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Investment|Energy Demand|{Residential/Commercial}|Building Envelope:
+    description: Investments into the building envelope in {Residential/Commercial}
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Investment|Energy Demand|{Residential/Commercial}|Heating and Cooling:
+    description: Investments into heating & cooling technologies in {Residential/Commercial}
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+
 - Investment|Energy Supply:
     description: Investments into the energy supply system
     unit: [million EUR_2020/yr, billion USD_2010/yr]
@@ -310,6 +324,20 @@
       For plants equipped with CCS, the investment in the capturing equipment should
       be included but not the one on transport and storage.
     unit: [million EUR_2020/yr, billion USD_2010/yr]
+
+- Running Costs|{Residential/Commercial}:
+    description: Operation and Maintenance as well as fuel costs in {Residential/Commercial}.
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Running Costs|{Residential/Commercial}|Operation and Maintenance:
+    description: Operation and Maintenance costs in {Residential/Commercial}.
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Running Costs|{Residential/Commercial}|Heating and Cooling|Fuel:
+    description: Fuel costs for heating and cooling in {Residential/Commercial}.
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Running Costs|{Residential/Commercial}|Appliances|Fuel:
+    description: Fuel costs for non-heating/cooling appliances in {Residential/Commercial}.
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+
 
 - Stock|Transportation|{Transport mode, tech and carrier}:
     description: Number of registered vehicles with {Transport mode, tech and carrier}


### PR DESCRIPTION
Some variable additions for the ECEMF WP2 focusing on the demand sectors. 

To be more symmetric to the `Investment|Energy Supply|xxx` categories, I added `Investment|Energy Demand` variables; at the moment only implemented for {Residential/Commercial}.

Also, I added a new category `Running Costs` that encompasses fuel costs and operation and maintenance costs. I currently used the form `Running Costs|{Residential and Commercial}|XX` , but this could also be changed to `Running Costs|Energy Demand|{Residential and Commercial}|XX`. 


























































