### PR TITLE
Add REMIND-Buildings 3.2

### DIFF
--- a/mappings/REMIND_3.2.yml
+++ b/mappings/REMIND_3.2.yml
@@ -1,6 +1,7 @@
 # this mapping only works for the 21-region version of REMIND 3.2
 model:
   - REMIND 3.2
+  - REMIND-Buildings 3.2
 native_regions:
   - CAZ: REMIND 3.2|Canada, Australia, New Zealand
   - CHA: REMIND 3.2|China and Taiwan


### PR DESCRIPTION
This adds the name of the sectoral version of REMIND 3.2 to the respective mapping.