### PR TITLE
Update electricity-grid.yaml

### DIFF
--- a/definitions/variable/technology/electricity-grid.yaml
+++ b/definitions/variable/technology/electricity-grid.yaml
@@ -5,7 +5,7 @@
     unit: km
 - Network|Electricity|Expansion Cost:
     description: Cost for increasing the line capacity
-    unit: million EUR/GW/km, EUR_2020/MW
+    unit: [million EUR/GW/km, EUR_2020/MW]
 - Network|Electricity|Capacity:
     description: Capacity of the line
     unit: MW

--- a/definitions/variable/technology/electricity-grid.yaml
+++ b/definitions/variable/technology/electricity-grid.yaml
@@ -5,7 +5,7 @@
     unit: km
 - Network|Electricity|Expansion Cost:
     description: Cost for increasing the line capacity
-    unit: million EUR/GW/km
+    unit: million EUR/GW/km, EUR_2020/MW
 - Network|Electricity|Capacity:
     description: Capacity of the line
     unit: MW


### PR DESCRIPTION
add unit EUR_2020/MW to allow using this variable for extension not only of the line length but also of the line capacity

We could also create a new variable whcih I would have named Network|Electricity[Capital Cost for consistance with the investment costs in other technologies which are named Capcital Cost