### PR TITLE
Update tag_storage_types.yaml

### DIFF
--- a/definitions/variable/tag_storage_types.yaml
+++ b/definitions/variable/tag_storage_types.yaml
@@ -6,8 +6,6 @@
 # does not include hydro 
 
 - Storage Type:
-  - Pumped Hydro:
-      description: pumped hydro storage
   - Battery:
       description: all batteries
   - Battery|Lithium-Ion:


### PR DESCRIPTION
The comment says 'does not include hydro' but Pumped Storage was still included.... which would create variables such as eg Capacity|Electricity|Pumped Storage while the use of Electricity Input creates Capacity|Electricity|Hydro|Pumped storage I propose to remove pumped storage from storage_types