### PR TITLE
Add and update (annualized) investment and running costs variables for demand sectors

### DIFF
--- a/definitions/variable/technology/README.md
+++ b/definitions/variable/technology/README.md
@@ -36,7 +36,7 @@ or tranmission lines should follow the structure below.
 Note that it usually does not make sense to report capital costs
 at a more aggregate level (i.e., `Capital Cost|{Fuel}`).
 
-## Investment expenditure
+## Investment expenditure (outdated/ superseded by investment variables split by sector - see below)
 
 Variables for the expenditure for new construction of power plants
 or tranmission lines should follow the structure below.
@@ -44,3 +44,35 @@ or tranmission lines should follow the structure below.
 - `Investment|{Type}`
 - `Investment|{Type}|{Fuel}`
 - `Investment|{Type}|{Fuel}|{Specification}`
+
+## Investment expenditures - Energy supply/demand sectors
+
+Variables for the investment expenditure in an energy (sub-)sectors (currently {Residential/Commercial}, Transportation, Electricity, Extraction, Heat, Hydrogen, and Liquids). Examples are 
+
+- `Investment|Energy Demand|Transportation`
+- `Investment|Energy Demand|{Residential/Commercial}`
+- `Investment|Energy Demand|{Residential/Commercial}|Appliances`
+- `Investment|Energy Demand|{Residential/Commercial}|Heating and Cooling|Heat Pumps`
+- `Investment|Energy Supply|Electricity|{Electricity Input}`
+- `Investment|Energy Supply|Extraction|Oil`
+- `Investment|Energy Supply|Liquids|Biomass`
+
+## Annualized Investments - Energy supply/demand sectors
+
+Annualized investments of the standing stock. This includes the annualized investments for all the currently standing stock that is not yet financially depreciated (which can happen earlier than the technical lifetime). The sum over the annualized investment should - over long periods that are longer than the depreciation periods - come close to the sum over investments; but it will be different on short periods if large investments are undertaken to change the system, which will strongly increase the “Investment” variable but have less impact on the “Annualized Investment” variable, which also includes the contribution for the standing stock. Towards the end of the modeling period, the annualized investment approach can give a better impression of the costs for the remaining years until end of the modelling period; the “Investment” variable also contains the investments whose lifetime lies mostly after the end of the modelling period. Example
+
+- `Annualized Investment|Energy Demand|{Residential/Commercial}`
+- `Annualized Investment|Energy Demand|Transportation|{Transport mode}`
+
+## Running Costs - Energy supply/demand sectors
+
+Variables for the running costs of a sector, eg {Residential/Commercial} or Transportation. Currently implemented subtypes are Operation and Maintenance, as well as Fuel
+
+- `Running Costs|Energy Demand|{Residential/Commercial}` 
+- `Running Costs|Energy Demand|Transportation|{Transport mode}|Fuel` 
+- `Running Costs|Energy Demand|Transportation|{Transport mode}|Fuel|{Fuel}` 
+
+## Stock and Sales of technologies within a sector
+
+- `Stock|Transportation|{Transport mode, tech and carrier}` 
+- `Sales|{Residential/Commercial}|Heat Pumps`

--- a/definitions/variable/technology/README.md
+++ b/definitions/variable/technology/README.md
@@ -47,7 +47,7 @@ or tranmission lines should follow the structure below.
 
 ## Investment expenditures - Energy supply/demand sectors
 
-Variables for the investment expenditure in an energy (sub-)sectors (currently {Residential/Commercial}, Transportation, Electricity, Extraction, Heat, Hydrogen, and Liquids). Examples are 
+Variables for the investment expenditure in an energy (sub-)sectors (currently {Residential/Commercial}, Transportation, Industry, Electricity, Extraction, Heat, Hydrogen, and Liquids). Examples are 
 
 - `Investment|Energy Demand|Transportation`
 - `Investment|Energy Demand|{Residential/Commercial}`
@@ -59,18 +59,19 @@ Variables for the investment expenditure in an energy (sub-)sectors (currently {
 
 ## Annualized Investments - Energy supply/demand sectors
 
-Annualized investments of the standing stock. This includes the annualized investments for all the currently standing stock that is not yet financially depreciated (which can happen earlier than the technical lifetime). The sum over the annualized investment should - over long periods that are longer than the depreciation periods - come close to the sum over investments; but it will be different on short periods if large investments are undertaken to change the system, which will strongly increase the “Investment” variable but have less impact on the “Annualized Investment” variable, which also includes the contribution for the standing stock. Towards the end of the modeling period, the annualized investment approach can give a better impression of the costs for the remaining years until end of the modelling period; the “Investment” variable also contains the investments whose lifetime lies mostly after the end of the modelling period. Example
+Annualized investments of the standing stock. This includes the annualized investments for all the currently standing stock that is not yet financially depreciated (which can happen earlier than the technical lifetime). The sum over the annualized investment should - over long periods that are longer than the depreciation periods - come close to the sum over investments; but it will be different on short periods if large investments are undertaken to change the system, which will strongly increase the "Investment" variable but have less impact on the "Annualized Investment" variable, which also includes the contribution for the standing stock. Towards the end of the modeling period, the annualized investment approach can give a better impression of the costs for the remaining years until end of the modelling period; the "Investment" variable also contains the investments whose lifetime lies mostly after the end of the modelling period. Example
 
 - `Annualized Investment|Energy Demand|{Residential/Commercial}`
 - `Annualized Investment|Energy Demand|Transportation|{Transport mode}`
 
 ## Running Costs - Energy supply/demand sectors
 
-Variables for the running costs of a sector, eg {Residential/Commercial} or Transportation. Currently implemented subtypes are Operation and Maintenance, as well as Fuel
+Variables for the running costs of a sector, eg {Residential/Commercial}, Transportation, Industry, Electricity, Hydrogen. Currently implemented subtypes are "Operation and Maintenance", as well as "Fuel"
 
 - `Running Costs|Energy Demand|{Residential/Commercial}` 
 - `Running Costs|Energy Demand|Transportation|{Transport mode}|Fuel` 
-- `Running Costs|Energy Demand|Transportation|{Transport mode}|Fuel|{Fuel}` 
+- `Running Costs|Energy Demand|Transportation|{Transport mode}|Fuel|{Fuel}`
+- `Running Costs|Energy Demand|Industry|Operation and Maintenance`
 
 ## Stock and Sales of technologies within a sector
 

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -380,9 +380,6 @@
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
 
 
-- Annualized Investment|Energy Demand|{Residential/Commercial}:
-    description: Annualized investments for the standing stock in {Residential/Commercial} (for a longer description, check the README).
-    unit: [billion EUR_2020/yr, billion USD_2010/yr]
 - Annualized Investment|Energy Demand|Transportation:
     description: Annualized investments for the standing stock in Transportation.
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
@@ -391,7 +388,7 @@
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
 
 - Annualized Investment|Energy Demand|{Residential/Commercial}:
-    description: Annualized investments for the standing stock in in {Residential/Commercial}
+    description: Annualized investments for the standing stock in {Residential/Commercial}
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
 - Annualized Investment|Energy Demand|{Residential/Commercial}|Appliances:
     description: Annualized investments for the standing stock of non-heating/cooling appliances in {Residential/Commercial}
@@ -411,13 +408,13 @@
     description: Number of registered vehicles with {Transport mode, tech and carrier}
     unit: million
 - Sales|Transportation|{Transport mode, tech and carrier}:
-    description: Number of sold (new) vehicles with {Transport mode, tech and carrier}
+    description: Number of yearly sold (new) vehicles with {Transport mode, tech and carrier}
     unit: million/yr
 - Stock|{Residential/Commercial}|Heat Pumps:
     description: Number of the standing stock of heat pumps in {Residential/Commercial}
     unit: million
 - Sales|{Residential/Commercial}|Heat Pumps:
-    description: Number of heat pumps sold in {Residential/Commercial}
+    description: Number of yearly sold (new) heat pumps in {Residential/Commercial}
     unit: million/yr
 
 - Infrastructure|Transportation|Charging Station:

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -237,13 +237,6 @@
     unit: [million EUR_2020/yr, billion USD_2010/yr]
 
 
-- Investment|Energy Demand|Transportation:
-    description: Total investments in Transportation
-    unit: [billion EUR_2020/yr, billion USD_2010/yr]
-- Investment|Energy Demand|Transportation|{Transport mode}:
-    description: Investments into the various transport modes
-    unit: [billion EUR_2020/yr, billion USD_2010/yr]
-
 - Investment|Energy Demand|{Residential/Commercial}:
     description: Total investments in {Residential/Commercial}
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
@@ -255,6 +248,16 @@
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
 - Investment|Energy Demand|{Residential/Commercial}|Heating and Cooling:
     description: Investments into heating & cooling technologies in {Residential/Commercial}
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Investment|Energy Demand|{Residential/Commercial}|Heating and Cooling|Heat Pumps:
+    description: Investments into heating & cooling technologies in {Residential/Commercial}
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+
+- Investment|Energy Demand|Transportation:
+    description: Total investments in Transportation
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Investment|Energy Demand|Transportation|{Transport mode}:
+    description: Investments into the various transport modes
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
 
 - Investment|Energy Supply:
@@ -338,41 +341,84 @@
       be included but not the one on transport and storage.
     unit: [million EUR_2020/yr, billion USD_2010/yr]
 
-- Running Costs|{Residential/Commercial}:
+- Running Costs|Energy Demand|{Residential/Commercial}:
     description: Operation and Maintenance as well as fuel costs in {Residential/Commercial}.
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
-- Running Costs|{Residential/Commercial}|Operation and Maintenance:
+- Running Costs|Energy Demand|{Residential/Commercial}|Operation and Maintenance:
     description: Operation and Maintenance costs in {Residential/Commercial}.
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
-- Running Costs|{Residential/Commercial}|Heating and Cooling|Fuel:
+- Running Costs|Energy Demand|{Residential/Commercial}|Heating and Cooling|Fuel:
     description: Fuel costs for heating and cooling in {Residential/Commercial}.
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
-- Running Costs|{Residential/Commercial}|Appliances|Fuel:
+- Running Costs|Energy Demand|{Residential/Commercial}|Heating and Cooling|Fuel|{Fuel}:
+    description: Fuel costs for specific fuel types in heating and cooling in {Residential/Commercial}.
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Running Costs|Energy Demand|{Residential/Commercial}|Appliances|Fuel:
     description: Fuel costs for non-heating/cooling appliances in {Residential/Commercial}.
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
 
-- Running Costs|Transportation:
+- Running Costs|Energy Demand|Transportation:
     description: Operation and Maintenance as well as fuel costs in Transportation.
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
-- Running Costs|Transportation|Operation and Maintenance:
+- Running Costs|Energy Demand|Transportation|Operation and Maintenance:
     description: Operation and Maintenance costs for Transportation.
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
-- Running Costs|Transportation|{Transport mode}|Operation and Maintenance:
+- Running Costs|Energy Demand|Transportation|{Transport mode}|Operation and Maintenance:
     description: Operation and Maintenance costs for {Transport mode} in Transportation.
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
-- Running Costs|Transportation|Fuel:
+- Running Costs|Energy Demand|Transportation|Fuel:
     description: Fuel costs for Transportation.
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
-- Running Costs|Transportation|{Transport mode}|Fuel:
-    description: Fuel costs for {Transport mode} in Transportation.
+- Running Costs|Energy Demand|Transportation|Fuel|{Fuel}:
+    description: Fuel costs for the specific fuel type {Fuel} in Transportation.
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Running Costs|Energy Demand|Transportation|{Transport mode}|Fuel:
+    description: Fuel costs for {Transport mode}.
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Running Costs|Energy Demand|Transportation|{Transport mode}|Fuel|{Fuel}:
+    description: Fuel costs for the specific fuel type {Fuel} in {Transport mode}.
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+
+
+- Annualized Investment|Energy Demand|{Residential/Commercial}:
+    description: Annualized investments for the standing stock in {Residential/Commercial} (for a longer description, check the README).
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Annualized Investment|Energy Demand|Transportation:
+    description: Annualized investments for the standing stock in Transportation.
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Annualized Investment|Energy Demand|Transportation|{Transport mode}:
+    description: Annualized investments for the standing stock of the various transport modes
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+
+- Annualized Investment|Energy Demand|{Residential/Commercial}:
+    description: Annualized investments for the standing stock in in {Residential/Commercial}
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Annualized Investment|Energy Demand|{Residential/Commercial}|Appliances:
+    description: Annualized investments for the standing stock of non-heating/cooling appliances in {Residential/Commercial}
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Annualized Investment|Energy Demand|{Residential/Commercial}|Building Envelope:
+    description: Annualized investments for the standing stock of the building envelope in {Residential/Commercial}
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Annualized Investment|Energy Demand|{Residential/Commercial}|Heating and Cooling:
+    description: Annualized investments for the standing stock of heating & cooling technologies in {Residential/Commercial}
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Annualized Investment|Energy Demand|{Residential/Commercial}|Heating and Cooling|Heat Pumps:
+    description: Annualized investments for the standing stock of heat pumps in {Residential/Commercial}
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+
 
 - Stock|Transportation|{Transport mode, tech and carrier}:
     description: Number of registered vehicles with {Transport mode, tech and carrier}
     unit: million
 - Sales|Transportation|{Transport mode, tech and carrier}:
     description: Number of sold (new) vehicles with {Transport mode, tech and carrier}
+    unit: million/yr
+- Stock|{Residential/Commercial}|Heat Pumps:
+    description: Number of the standing stock of heat pumps in {Residential/Commercial}
     unit: million
+- Sales|{Residential/Commercial}|Heat Pumps:
+    description: Number of heat pumps sold in {Residential/Commercial}
+    unit: million/yr
 
 - Infrastructure|Transportation|Charging Station:
     description: Number of charging stations for electric vehicles

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -259,6 +259,10 @@
 - Investment|Energy Demand|Transportation|{Transport mode}:
     description: Investments into the various transport modes
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
+    
+- Investment|Energy Demand|Industry:
+    description: Total investments in Industry
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
 
 - Investment|Energy Supply:
     description: Investments into the energy supply system
@@ -379,6 +383,18 @@
     description: Fuel costs for the specific fuel type {Fuel} in {Transport mode}.
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
 
+- Running Costs|Energy Demand|Industry:
+    description: Operation and Maintenance as well as fuel costs in Industry.
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Running Costs|Energy Demand|Industry|Fuel:
+    description: Fuel costs in Industry.
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Running Costs|Energy Demand|Industry|Fuel|{Fuel}:
+    description: Fuel costs for the specific fuel type {Fuel} in Industry.
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
+- Running Costs|Energy Demand|Industry|Operation and Maintenance:
+    description: Operation and Maintenance costs in Industry.
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
 
 - Annualized Investment|Energy Demand|Transportation:
     description: Annualized investments for the standing stock in Transportation.
@@ -403,6 +419,9 @@
     description: Annualized investments for the standing stock of heat pumps in {Residential/Commercial}
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
 
+- Annualized Investment|Energy Demand|Industry:
+    description: Annualized investments for the standing stock in Industry
+    unit: [billion EUR_2020/yr, billion USD_2010/yr]
 
 - Stock|Transportation|{Transport mode, tech and carrier}:
     description: Number of registered vehicles with {Transport mode, tech and carrier}


### PR DESCRIPTION
For ECEMF WP2: 
+ Add "Annualized Investment" variable.
+ Add "Energy Demand" information to "Running costs" variable.
+ Add further splits to (Annualized) Investment, Running costs and Stock/Sales variables
+ update the README file to represent the latest changes
+ add these variables also for the industry sector