### PR TITLE
Update countries.yaml

### DIFF
--- a/definitions/region/countries.yaml
+++ b/definitions/region/countries.yaml
@@ -161,7 +161,7 @@
       iso3_codes: MKD
   - Norway:
       eu_member: false
-      iso2: NO
+      iso2: 'NO'
       iso3: NOR
       iso3_codes: NOR
   - Poland:


### PR DESCRIPTION
changed iso2 code of norway from NO to 'NO' because python yaml understood NO as False, not as a 2 characters string