### PR TITLE
Add variables for capacity additions

### DIFF
--- a/definitions/variable/tag_electricity_input_types.yaml
+++ b/definitions/variable/tag_electricity_input_types.yaml
@@ -280,13 +280,7 @@
       description: hydrogen used in combined cycle gas turbine (CCGT) power plants not generating heat
 
   - Hydro:
-      description: hydropower
-  - Hydro|Pumped Storage:
-      description: hydropower systems with short-term storage capacity
-        (including pumping turbines)
-      notes: This hydropower system has two water reservoirs at different elevations.
-        The definition follows the convention established
-        by the ENTSO-E transparency platform (https://transparency.entsoe.eu).
+      description: hydropower - includes reservoir and run-of-river, but NOT pumped hydro
   - Hydro|Reservoir:
       description: hydropower systems with seasonal storage capacity
         (possibly including pumping turbines)

--- a/definitions/variable/tag_electricity_input_types.yaml
+++ b/definitions/variable/tag_electricity_input_types.yaml
@@ -280,12 +280,19 @@
       description: hydrogen used in combined cycle gas turbine (CCGT) power plants not generating heat
 
   - Hydro:
-      description: hydropower - includes reservoir and run-of-river, but NOT pumped hydro
+      description: hydropower
+  - Hydro|Pumped Storage:
+      description: hydropower systems with pumping turbines
+      notes: This hydropower system has two water reservoirs at different elevations.
+        The definition follows the convention established by the ENTSO-E transparency platform
+         (https://eepublicdownloads.entsoe.eu/clean-documents/sdc-documents/MAF/2020/Hydropower_Modelling_New_database_and_methodology_V1_0.pdf).
+  - Hydro|Pumped Storage|Closed-Loop:
+      description: hydropower systems with pumping but NO natural inflows
+  - Hydro|Pumped Storage|Open-Loop:
+      description: hydropower systems with pumping and natural inflows
   - Hydro|Reservoir:
-      description: hydropower systems with seasonal storage capacity
-        (possibly including pumping turbines)
+      description: hydropower systems with >24h storage capacity
       notes: This definition follows the convention established
-        by the ENTSO-E transparency platform (https://transparency.entsoe.eu).
   - Hydro|Run of River:
       description: run-of-river hydro power plants (i.e. without storage capacity)
 

--- a/definitions/variable/tag_storage_types.yaml
+++ b/definitions/variable/tag_storage_types.yaml
@@ -15,7 +15,13 @@
   - Compressed Air:
       description: compressed air storage systems
   - Pumped Hydro:
-      description: pumped hydro storage systems - without external inflow (hydro storage with inflow should be reported under "Capacity|Electricity|Hydro")     
+      description: pumped hydro storage systems     
+  - Pumped Hydro|Closed-Loop:
+      description: pumped hydro storage systems with no natural inflow
+      notes: The definition follows the convention established by the ENTSO-E transparency platform
+         (https://eepublicdownloads.entsoe.eu/clean-documents/sdc-documents/MAF/2020/Hydropower_Modelling_New_database_and_methodology_V1_0.pdf).
+  - Pumped Hydro|Open-Loop:
+      description: pumped hydro storage systems with natural inflow
   - Heat:
       description: all types of heat storage systems
   - Electric Vehicle:

--- a/definitions/variable/tag_storage_types.yaml
+++ b/definitions/variable/tag_storage_types.yaml
@@ -14,6 +14,8 @@
       description: redox flow batteries
   - Compressed Air:
       description: compressed air storage systems
+  - Pumped Hydro:
+      description: pumped hydro storage systems - without external inflow (hydro storage with inflow should be reported under "Capacity|Electricity|Hydro")     
   - Heat:
       description: all types of heat storage systems
   - Electric Vehicle:

--- a/definitions/variable/technology/README.md
+++ b/definitions/variable/technology/README.md
@@ -21,9 +21,18 @@ See [technologies.yaml](technologies.yaml) for the full codelist.
 Variables for the installed capacity of (energy) production/generation
 or transmission should follow the structure below.
 
-- `Capacity|{Fuel}`
-- `Capacity|{Fuel}|{Specification}`
-- `Capacity|{Fuel}|{Specification}|{Identifier Of A Specific Power Plant}`
+- `Capacity|{Output}`
+- `Capacity|{Output}|{Specification}`
+- `Capacity|{Output}|{Input}`
+
+## Capacity Additions
+
+Variables for capacity additions of (energy) production/generation
+or transmission should follow the structure below.
+
+- `Capacity Additions|{Output}`
+- `Capacity Additions|{Output}|{Specification}`
+- `Capacity Additions|{Output}|{Input}`
 
 ## Capital Cost
 

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -120,23 +120,36 @@
     description: Total installed (available) capacity of hydrogen-to-liquids (synfuel) plants
     unit: GW
 
+- Capacity|Heat:
+    description: Total installed centralized heat generation capacity
+    unit: GW
+- Capacity|Heat|{Fuel}:
+    description: Total installed centralized heat generation capacity from {Fuel}
+    unit: GW
+- Capacity|Heat|Heat Pumps:
+    description: Total installed centralized heat generation capacity by heat pumps 
+    unit: GW
+
 - Capacity|Heat|Residential and Commercial:
-    description: Total installed heat generation capacity for the residential and
+    description: Total installed centralized heat generation capacity for the residential and
       commercial sectors
     unit: GW
 - Capacity|Heat|Residential and Commercial|{Fuel}:
-    description: Total installed heat generation capacity for the residential and
+    description: Total installed centralized heat generation capacity for the residential and
       commercial sectors from {Fuel}
     unit: GW
 - Capacity|Heat|{Residential/Commercial}|Heat Pumps:
-    description: Total installed capacity of heat pumps for {Residential/Commercial} buildings
+    description: Total installed centralized heat generation capacity by heat pumps for {Residential/Commercial} buildings
     unit: GW
 - Capacity|Heat|Industrial:
-    description: Total installed heat generation capacity for the industrial sector
+    description: Total installed centralized heat generation capacity for the industrial sector
     unit: GW
 - Capacity|Heat|Industrial|{Fuel}:
-    description: Total installed heat generation capacity for the industrial sector
+    description: Total installed centralized heat generation capacity for the industrial sector
       from {Fuel}
+    unit: GW
+- Capacity|Heat|Industrial||Heat Pumps:
+    description: Total installed centralized heat generation capacity by heat pumps for the industrial sector
     unit: GW
 - Capacity|Transportation|{Transport mode}:
     description: Maximum amount of pkms or tkms that can be transported per year by {Transport mode}
@@ -144,6 +157,170 @@
 - Capacity|Transportation|{Bunkers mode}:
     description: Maximum amount of pkms or tkms that can be transported per year by {Transport mode}
     unit: [billion pkm/yr, billion tkm/yr]
+
+
+- Capacity Additions|Electricity:
+    description: Total added electricity generation capacity
+    unit: GW/yr
+- Capacity Additions|Electricity|{Electricity Input}:
+    description: Total added electricity generation capacity from {Electricity Input}
+    unit: GW/yr
+- Capacity Additions|Electricity|{Storage Type}:
+    description: Total added electricity generation capacity from {Storage Type}
+    unit: GW/yr
+- Capacity Additions|Electricity|Storage|Power:
+    description: Total added capacity of operating electricity storage (e.g. pumped hydro, batteries, compressed air storage)
+          in terms of electricity output capacity
+    unit: GW/yr
+- Capacity Additions|Electricity|Storage|Power|{Storage Type}:
+    description: Total added capacity of operating electricity storage from {Storage Type}
+          in terms of electricity output capacity
+    unit: GW/yr
+- Capacity Additions|Electricity|Storage|Reservoir:
+    description: Added reservoir size of electricity storage technologies (e.g. pumped hydro, batteries, compressed air storage) 
+          in terms of stored electric energy
+    unit: GWh/yr
+- Capacity Additions|Electricity|Storage|Reservoir|{Storage Type}:
+    description: Added reservoir size of electricity storage technologies from {Storage Type}
+          in terms of stored electric energy
+    unit: GWh/yr
+- Capacity Additions|Gases:
+    description: Total capacity additions of gas plants
+    unit: GW/yr
+- Capacity Additions|Gases|Biomass:
+    description: Total capacity additions of biomass to gas plants
+    unit: GW/yr
+- Capacity Additions|Gases|Biomass|w/ CCS:
+    description: Total capacity additions of biomass to gas plants with CCS
+    unit: GW/yr
+- Capacity Additions|Gases|Biomass|w/o CCS:
+    description: Total capacity additions of biomass to gas plants without CCS
+    unit: GW/yr
+- Capacity Additions|Gases|Coal:
+    description: Total capacity additions of coal to gas plants
+    unit: GW/yr
+- Capacity Additions|Gases|Coal|w/ CCS:
+    description: Total capacity additions of coal to gas plants with CCS
+    unit: GW/yr
+- Capacity Additions|Gases|Coal|w/o CCS:
+    description: Total capacity additions of coal to gas plants without CCS
+    unit: GW/yr
+- Capacity Additions|Gases|Hydrogen:
+    description: Total capacity additions of hydrogen-to-methane (syngas) plants
+    unit: GW/yr
+- Capacity Additions|Hydrogen:
+    description: Total capacity additions of hydrogen plants (in hydrogen output)
+    unit: GW/yr
+- Capacity Additions|Hydrogen|Biomass:
+    description: Total capacity additions of biomass to hydrogen plants (in hydrogen output)
+    unit: GW/yr
+- Capacity Additions|Hydrogen|Biomass|w/ CCS:
+    description: Total capacity additions of biomass to hydrogen plants with CCS (in hydrogen output)
+    unit: GW/yr
+- Capacity Additions|Hydrogen|Biomass|w/o CCS:
+    description: Total capacity additions of biomass to hydrogen plants without CCS (in hydrogen output)
+    unit: GW/yr
+- Capacity Additions|Hydrogen|Coal:
+    description: Total capacity additions of coal to hydrogen plants (in hydrogen output)
+    unit: GW/yr
+- Capacity Additions|Hydrogen|Coal|w/ CCS:
+    description: Total capacity additions of coal to hydrogen plants with CCS (in hydrogen output)
+    unit: GW/yr
+- Capacity Additions|Hydrogen|Coal|w/o CCS:
+    description: Total capacity additions of coal to hydrogen plants without CCS (in hydrogen output)
+    unit: GW/yr
+- Capacity Additions|Hydrogen|Electricity:
+    description: Total capacity additions of hydrogen-by-electrolysis plants (in hydrogen output)
+    unit: GW/yr
+- Capacity Additions|Hydrogen|Input|Electricity:
+    description: Total capacity additions of hydrogen-by-electrolysis plants (in electricity input)
+    unit: GW/yr
+- Capacity Additions|Hydrogen|Gas:
+    description: Total capacity additions of gas to hydrogen plants (in hydrogen output)
+    unit: GW/yr
+- Capacity Additions|Hydrogen|Gas|w/ CCS:
+    description: Total capacity additions of gas to hydrogen plants with CCS (in hydrogen output)
+    unit: GW/yr
+- Capacity Additions|Hydrogen|Gas|w/o CCS:
+    description: Total capacity additions of gas to hydrogen plants without CCS (in hydrogen output)
+    unit: GW/yr
+- Capacity Additions|Liquids:
+    description: Total capacity additions of biomass to liquids plants
+    unit: GW/yr
+- Capacity Additions|Liquids|Biomass:
+    description: Total capacity additions of biomass to liquids plants
+    unit: GW/yr
+- Capacity Additions|Liquids|Biomass|w/ CCS:
+    description: Total capacity additions of biomass to liquids plants with CCS
+    unit: GW/yr
+- Capacity Additions|Liquids|Biomass|w/o CCS:
+    description: Total capacity additions of biomass to liquids plants without CCS
+    unit: GW/yr
+- Capacity Additions|Liquids|Coal:
+    description: Total capacity additions of coal to liquids plants
+    unit: GW/yr
+- Capacity Additions|Liquids|Coal|w/ CCS:
+    description: Total capacity additions of coal to liquids plants with CCS
+    unit: GW/yr
+- Capacity Additions|Liquids|Coal|w/o CCS:
+    description: Total capacity additions of coal to liquids plants without CCS
+    unit: GW/yr
+- Capacity Additions|Liquids|Gas:
+    description: Total capacity additions of gas to liquids plants
+    unit: GW/yr
+- Capacity Additions|Liquids|Gas|w/ CCS:
+    description: Total capacity additions of gas to liquids plants with CCS
+    unit: GW/yr
+- Capacity Additions|Liquids|Gas|w/o CCS:
+    description: Total capacity additions of gas to liquids plants without CCS
+    unit: GW/yr
+- Capacity Additions|Liquids|Oil:
+    description: Total capacity additions of oil refining plants
+    unit: GW/yr
+- Capacity Additions|Liquids|Hydrogen:
+    description: Total capacity additions of hydrogen-to-liquids (synfuel) plants
+    unit: GW/yr
+
+- Capacity Additions|Heat:
+    description: Additions to total installed centralized heat generation capacity 
+    unit: GW/yr
+- Capacity Additions|Heat|{Fuel}:
+    description: Additions to total installed centralized heat generation capacity from {Fuel}
+    unit: GW/yr
+- Capacity Additions|Heat|Heat Pumps:
+    description: Additions to total installed centralized heat generation capacity by heat pumps
+    unit: GW/yr
+- Capacity Additions|Heat|Residential and Commercial:
+    description: Additions to total installed centralized heat generation capacity for the residential and
+      commercial sectors
+    unit: GW/yr
+- Capacity Additions|Heat|Residential and Commercial|{Fuel}:
+    description: Additions to total installed centralized heat generation capacity for the residential and
+      commercial sectors from {Fuel}
+    unit: GW/yr
+- Capacity Additions|Heat|{Residential/Commercial}|Heat Pumps:
+    description: Additions to total installed capacity of centralized heat generation capacity  from heat pumps for {Residential/Commercial} buildings
+    unit: GW/yr
+- Capacity Additions|Heat|Industrial:
+    description: Additions to total installed centralized heat generation capacity for the industrial sector
+    unit: GW/yr
+- Capacity Additions|Heat|Industrial|{Fuel}:
+    description: Additions to total installed centralized heat generation capacity for the industrial sector
+      from {Fuel}
+    unit: GW/yr
+- Capacity Additions|Heat|Industrial|Heat Pumps:
+    description: Additions to total installed capacity of centralized heat generation capacity from heat pumps for the industrial sector
+    unit: GW/yr
+- Capacity Additions|Transportation|{Transport mode}:
+    description: Additions to maximum amount of pkms or tkms that can be transported per year by {Transport mode}
+    unit: [billion pkm/yr/yr, billion tkm/yr/yr]
+- Capacity Additions|Transportation|{Bunkers mode}:
+    description: Additions to maximum amount of pkms or tkms that can be transported per year by {Transport mode}
+    unit: [billion pkm/yr/yr, billion tkm/yr/yr]
+
+
+
+    
 - Efficiency|Hydrogen|Electricity:
     description: Efficiency of producing hydrogen from electricity
     unit: "%"


### PR DESCRIPTION
Add variables for capacity additions. 

In the process, clarified the subtypes of pumped hydro, and included pumped hydro in storage tags. 

Also clarified that "Heat" is "centralized heat generation", and not heat generation in buildings or so. Accordingly, `Capacity|Heat|Residential and Commercial|Heat Pumps` does not give the capacity of heat pumps in buildings, but rather the capacity of large-scale heat pumps in district heating networks supplying residential&commercial buildings. 

 