### PR TITLE
add hydrogen SE and FE and gross trade SE

### DIFF
--- a/definitions/variable/energy/energy-secondary.yaml
+++ b/definitions/variable/energy/energy-secondary.yaml
@@ -84,7 +84,7 @@
     description: Total centralized heat generation from {Fuel}
     unit: EJ/yr
 - Secondary Energy|Heat|Electricity|Heat Pumps:
-    description: Total centralized heat generation from heat pumps ("Electricity" is already covered in {Fuel})
+    description: Total centralized heat generation from heat pumps
     unit: EJ/yr
 - Secondary Energy|Heat|Nuclear:
     description: centralized heat generation from nuclear energy

--- a/definitions/variable/energy/energy-secondary.yaml
+++ b/definitions/variable/energy/energy-secondary.yaml
@@ -24,6 +24,22 @@
     description: Curtailment of electricity production due to oversupply from
       variable renewable sources (typically from wind and solar)
     unit: [EJ/yr, GWh]
+- Secondary Energy|Electricity|Curtailment|Solar:
+    description: Curtailment of electricity from solar
+    unit: [EJ/yr, GWh]
+- Secondary Energy|Electricity|Curtailment|Solar|PV:
+    description: Curtailment of electricity from solar PV
+    unit: [EJ/yr, GWh]
+- Secondary Energy|Electricity|Curtailment|Wind:
+    description: Curtailment of electricity from wind
+    unit: [EJ/yr, GWh]
+- Secondary Energy|Electricity|Curtailment|Wind|Offshore:
+    description: Curtailment of electricity from wind offshore
+    unit: [EJ/yr, GWh]
+- Secondary Energy|Electricity|Curtailment|Wind|Onshore:
+    description: Curtailment of electricity from wind onshore
+    unit: [EJ/yr, GWh]
+
 - Secondary Energy|Electricity|Storage:
     description: electricity storage from other periods used
     unit: [EJ/yr, GWh]
@@ -41,10 +57,16 @@
     description: Total production of biogas
     unit: EJ/yr
 - Secondary Energy|Gases|Fossil:
-    description: total production of gas from fossils
+    description: total production of gases from fossils
     unit: EJ/yr
 - Secondary Energy|Gases|Electricity:
-    description: total production of gas from electricity (power to gas)
+    description: total production of gases from electricity (power to gas)
+      (if hydrogen is not explicitly modeled as an intermediate product)
+    unit: EJ/yr
+- Secondary Energy|Gases|Hydrogen:
+    description: Production of gases from hydrogen (if hydrogen is explicitly
+      modeled as a commodity and not an implicit intermediate product of the
+      transformation technologies)
     unit: EJ/yr
 - Secondary Energy|Gases|Other:
     description: total production of gases from sources that do not fit any other category
@@ -56,10 +78,13 @@
     description: Total production of fossil natural gas
     unit: EJ/yr
 - Secondary Energy|Heat:
-    description: Total heat generation
+    description: Total centralized heat generation
     unit: EJ/yr
 - Secondary Energy|Heat|{Fuel}:
-    description: Total heat generation from {Fuel}
+    description: Total centralized heat generation from {Fuel}
+    unit: EJ/yr
+- Secondary Energy|Heat|Electricity|Heat Pumps:
+    description: Total centralized heat generation from heat pumps ("Electricity" is already covered in {Fuel})
     unit: EJ/yr
 - Secondary Energy|Heat|Nuclear:
     description: centralized heat generation from nuclear energy
@@ -125,7 +150,13 @@
     description: total production of fossil liquid synfuels from facilities without CCS
     unit: EJ/yr
 - Secondary Energy|Liquids|Electricity:
-    description: total production of liquid fuels from electricity (efuels)
+    description: total production of liquid fuels from electricity (efuels) 
+      (if hydrogen is not explicitly modeled as an intermediate product)
+    unit: EJ/yr
+- Secondary Energy|Liquids|Hydrogen:
+    description: Production of liquids from hydrogen (if hydrogen is explicitly
+      modeled as a commodity and not an implicit intermediate product of the
+      transformation technologies)
     unit: EJ/yr
 - Secondary Energy|Liquids|Other:
     description: total production of liquids from sources that do not fit any other category
@@ -215,6 +246,12 @@
 - Trade|Secondary Energy|Electricity|Volume:
     description: Net exports of electricity
     notes: at the global level these should add up to the trade losses only
+    unit: EJ/yr
+- Trade|Gross Export|Secondary Energy|Electricity|Volume:
+    description: Gross exports of electricity
+    unit: EJ/yr
+- Trade|Gross Imports|Secondary Energy|Electricity|Volume:
+    description: Gross imports of electricity
     unit: EJ/yr
 - Trade|Secondary Energy|Hydrogen|Volume:
     description: Net exports of hydrogen

--- a/definitions/variable/tag_fe_carriers.yaml
+++ b/definitions/variable/tag_fe_carriers.yaml
@@ -15,8 +15,14 @@
       weight: Gases|Biomass
 
   - Gases|Electricity:
-      description: synthetic gaseous efuels ("power-to-gas")
+      description: synthetic gaseous efuels ("power-to-gas") (if hydrogen
+          is not explicitly modeled as an intermediate product)
       weight: Gases|Electricity
+
+  - Gases|Hydrogen:
+      description: synthetic gaseous efuels from hydrogen (if hydrogen is explicitly modeled as a
+          commodity and not an implicit intermediate product of the transformation technologies)
+      weight: Gases|Hydrogen
 
   - Gases|Fossil:
       description: synthetic or derived gases of fossil origin
@@ -55,8 +61,14 @@
       weight: Liquids|Biomass
 
   - Liquids|Electricity:
-      description: synthetic liquid efuels ("power-to-liquid")
+      description: synthetic liquid efuels ("power-to-liquid") (if hydrogen
+          is not explicitly modeled as an intermediate product)
       weight: Liquids|Electricity
+
+  - Liquids|Hydrogen:
+      description: liquid fuels from hydrogen (if hydrogen is explicitly modeled as a
+          commodity and not an implicit intermediate product of the transformation technologies)
+      weight: Liquids|Hydrogen
 
   - Liquids|Fossil:
       description: liquids from fossil origin (conventional & unconventional petroleum, coal-to-liquids, gas-to-liquids)


### PR DESCRIPTION
Add gross trade values for electricity

Add liquids/gases from hydrogen to Secondary Energy when hydrogen is modelled as a commodity (see also discussion in https://github.com/IAMconsortium/common-definitions/pull/106#issuecomment-2328867412 )

Also add sub-variables for Curtailment for an analysis on storage/curtailment in ECEMF. 

Also added centralized heat generation by heat pumps