### PR TITLE
Fix stray tags in descriptions

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -26,4 +26,4 @@ jobs:
       run: pip install -e .
 
     - name: Run the nomenclature project validation
-      run: nomenclature validate-project . --dimension region --dimension variable
+      run: nomenclature validate-project . --dimension region --dimension variable --dimension subannual

--- a/definitions/variable/technology/electricity-expansion.yaml
+++ b/definitions/variable/technology/electricity-expansion.yaml
@@ -6,7 +6,7 @@
       this capacity is added to the existing capacity
     unit: MW
 - Commissioned Storage|Electricity|{Storage Type}:
-    description: New storage capacity for {Electricity Storage Type},
+    description: New storage capacity for {Storage Type},
       this capacity is added to the existing capacity
     unit: MWh
 - Commissioned Capacity|Network|Electricity:
@@ -18,7 +18,7 @@
       this capacity is substracted from the existing capacity
     unit: MW
 - Decommissioned Storage|Electricity|{Storage Type}:
-    description: Removed storage capacity for {Electricity Storage Type},
+    description: Removed storage capacity for {Storage Type},
       this capacity is substracted from the existing capacity
     unit: MWh
 - Decommissioned Capacity|Network|Electricity:

--- a/definitions/variable/technology/electricity-operation.yaml
+++ b/definitions/variable/technology/electricity-operation.yaml
@@ -57,12 +57,12 @@
 - Spillage|Electricity|Hydro|Reservoir:
     description: Energy spillage that could not be stored by  Hydro Reservoir . Several energy models include spillage variables related to renewable
       energy production; however, another way is to include a spillage variable to
-      the {Storage Type} unit since it is the last sink of the power network
+      the hydro reservoir unit since it is the last sink of the power network
     unit: [MWh, GWh]
 - Spillage|Electricity|Hydro|Pumped Storage:
     description: Energy spillage that could not be stored by  pumped storage . Several energy models include spillage variables related to renewable
       energy production; however, another way is to include a spillage variable to
-      the {Storage Type} unit since it is the last sink of the power network
+      the pumped-storage unit since it is the last sink of the power network
     unit: [MWh, GWh]
 
 - Operation Cost|Electricity|{Electricity Input}:

--- a/definitions/variable/technology/power-plant.yaml
+++ b/definitions/variable/technology/power-plant.yaml
@@ -164,7 +164,7 @@
     unit: '-'
     skip-region-aggregation: true
 - Discharging Efficiency|Electricity|{Storage Type}:
-    description: Efficiency of discharging for a {Electricity Storage Type}
+    description: Efficiency of discharging for a {Storage Type}
     unit: '-'
     skip-region-aggregation: true
 - Discharging Efficiency|Electricity|Hydro|Pumped Storage:
@@ -176,7 +176,7 @@
     unit: '-'
     skip-region-aggregation: true
 - Inflows|Electricity|{Storage Type}:
-    description: Inflows into a storage of a {Electricity Storage Type}, expressed in energy
+    description: Inflows into a storage of a {Storage Type}, expressed in energy
     unit: GWh
 - Inflows|Electricity|Hydro|Reservoir:
     description: Inflows into a hydro reservoir, expressed in energy
@@ -202,7 +202,7 @@
     unit: '-'
     skip-region-aggregation: true
 - Seasonality|Electricity|{Storage Type}:
-    description: seasonality (daily, weekly, monthly, etc.) of {Electricity Storage Type}
+    description: seasonality (daily, weekly, monthly, etc.) of {Storage Type}
     unit: [daily,weekly,monthly]
 - Roundtrip Efficiency|Electricity|{Storage Type}:
     description: Efficiency when charging energy from the grid to the system

--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -155,7 +155,7 @@
     description: Maximum amount of pkms or tkms that can be transported per year by {Transport mode}
     unit: [billion pkm/yr, billion tkm/yr]
 - Capacity|Transportation|{Bunkers mode}:
-    description: Maximum amount of pkms or tkms that can be transported per year by {Transport mode}
+    description: Maximum amount of pkms or tkms that can be transported per year by {Bunkers mode}
     unit: [billion pkm/yr, billion tkm/yr]
 
 
@@ -315,12 +315,9 @@
     description: Additions to maximum amount of pkms or tkms that can be transported per year by {Transport mode}
     unit: [billion pkm/yr/yr, billion tkm/yr/yr]
 - Capacity Additions|Transportation|{Bunkers mode}:
-    description: Additions to maximum amount of pkms or tkms that can be transported per year by {Transport mode}
+    description: Additions to maximum amount of pkms or tkms that can be transported per year by {Bunkers mode}
     unit: [billion pkm/yr/yr, billion tkm/yr/yr]
 
-
-
-    
 - Efficiency|Hydrogen|Electricity:
     description: Efficiency of producing hydrogen from electricity
     unit: "%"


### PR DESCRIPTION
The new nomenclature sanity-checking feature identified a number of wrong tags used in variable-descriptions. Very nice!

FYI @dc-almeida @phackstock