### PR TITLE
add aggregated sales/stock variables

### DIFF
--- a/definitions/variable/technology/technologies.yaml
+++ b/definitions/variable/technology/technologies.yaml
@@ -666,9 +666,15 @@
     description: Annualized investments for the standing stock in Industry
     unit: [billion EUR_2020/yr, billion USD_2010/yr]
 
+- Stock|Transportation|{Transport mode}:
+    description: Number of registered vehicles in {Transport mode}
+    unit: million
 - Stock|Transportation|{Transport mode, tech and carrier}:
     description: Number of registered vehicles with {Transport mode, tech and carrier}
     unit: million
+- Sales|Transportation|{Transport mode}:
+    description: Number of yearly sold (new) vehicles in {Transport mode}
+    unit: million/yr
 - Sales|Transportation|{Transport mode, tech and carrier}:
     description: Number of yearly sold (new) vehicles with {Transport mode, tech and carrier}
     unit: million/yr


### PR DESCRIPTION
in `{Transport mode, tech and carrier}`, only the detailed categories (eg "Bus|BEV") are not contained, not the aggregated category ("Bus"). 

Therefore, the more aggregated categories were added by adding a "{Transport mode}" entry for Sales/Stock 