### PR TITLE
Add total energy system cost variable

### DIFF
--- a/definitions/variable/economy/economy.yaml
+++ b/definitions/variable/economy/economy.yaml
@@ -143,6 +143,10 @@
     unit: '%'
     skip-region-aggregation: true
 
+- Energy System Cost:
+    description: Total energy system cost
+    unit: [billion USD_2010/yr, billion EUR_2020/yr]
+
 - GDP|MER:
     description: GDP at market exchange rate
     unit: [billion USD_2010/yr, billion EUR_2020/yr]


### PR DESCRIPTION
To make the "Policy Cost|Additional total energy system cost" less failure-prone, it is better to have the actual total energy system costs explicitly for each scenario, so that the delta can be calculated in the analysis itself. Also, this allows for easier consistency checks between models (how similar are the boundaries of what they count under "energy system costs")