### PR TITLE
Update energy-secondary.yaml for typo in trade of electricity

### DIFF
--- a/definitions/variable/energy/energy-secondary.yaml
+++ b/definitions/variable/energy/energy-secondary.yaml
@@ -262,7 +262,7 @@
 - Trade|Gross Export|Secondary Energy|Electricity|Volume:
     description: Gross exports of electricity
     unit: EJ/yr
-- Trade|Gross Imports|Secondary Energy|Electricity|Volume:
+- Trade|Gross Import|Secondary Energy|Electricity|Volume:
     description: Gross imports of electricity
     unit: EJ/yr
 - Trade|Secondary Energy|Hydrogen|Volume:


### PR DESCRIPTION
"Trade|Gross Imports" should be "Trade|Gross Import" (without "s") to be consistent with the variable list in WP1.